### PR TITLE
add customCpu attribute

### DIFF
--- a/paths/api@service-plans.yaml
+++ b/paths/api@service-plans.yaml
@@ -114,6 +114,10 @@ post:
                       type: integer
                       format: int64
                       description: Provision type ID
+                customCpu:
+                  type: boolean
+                  description: Can be used to enable / disable customizable cpu
+                  default: false
                 customCores:
                   type: boolean
                   description: Can be used to enable / disable customizable cores


### PR DESCRIPTION
- customCpu attribute allows instance's to set their own maxCpu.