### PR TITLE
network resource: tweak zonePool id

### DIFF
--- a/components/examples/networkCreateRequestGcp.json
+++ b/components/examples/networkCreateRequestGcp.json
@@ -12,11 +12,11 @@
     "zone": {
       "id": 143
     },
+    "zonePool": {
+      "id": 3772
+    },
     "config": {
         "mtu": "1460",
-        "zonePool": {
-            "id": 3772
-        },
         "autoCreate": true
     },
     "cidr": "192.168.12.0/24",

--- a/components/examples/networkCreateSuccessGcp.json
+++ b/components/examples/networkCreateSuccessGcp.json
@@ -66,7 +66,9 @@
         "assignPublicIp": false,
         "noProxy": null,
         "applianceUrlProxyBypass": true,
-        "zonePool": null,
+        "zonePool": {
+            "id": 3772
+        },
         "allowStaticOverride": true,
         "subnets": [],
         "tenants": [],

--- a/components/schemas/networkCreate.yaml
+++ b/components/schemas/networkCreate.yaml
@@ -102,6 +102,13 @@ properties:
       - 'null'
     format: int64
     description: IPv6 Network Pool ID
+  zonePool:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Morpheus zone pool ID of the GCP Project for the network
   allowStaticOverride:
     type: boolean
     description: Allow IP Override

--- a/components/schemas/networkTypeGcpConfig.yaml
+++ b/components/schemas/networkTypeGcpConfig.yaml
@@ -1,7 +1,6 @@
 type: object
 required:
   - mtu
-  - zonePool
   - autoCreate
 properties: 
   mtu:
@@ -11,14 +10,6 @@ properties:
     enum:
       - "1460"
       - "1500"
-  zonePool:
-    type: object
-    required:
-      - id
-    properties:
-      id:
-        type: integer
-        description: Morpheus resource pool ID of the GCP Project for the network.
   autoCreate:
     type: boolean
     description: Auto create subnets

--- a/components/schemas/networkUpdate.yaml
+++ b/components/schemas/networkUpdate.yaml
@@ -36,6 +36,13 @@ properties:
       - 'null'
     format: int64
     description: Network Pool ID
+  zonePool:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Morpheus zone pool ID of the GCP Project for the network
   allowStaticOverride:
     type: boolean
     description: Allow IP Override


### PR DESCRIPTION
When creating a GCP network, the zonePool id goes
at the top level, not inside `config`. For example here is json created by the morpheus ruby cli:

```
{
  "network": {
    "active": "on",
    "applianceUrlProxyBypass": "on",
    "config": {
      "autoCreate": "off",
      "mtu": 1460
    },
    "description": "desc",
    "dhcpServer": null,
    "displayName": null,
    "ipv4Enabled": true,
    "ipv6Enabled": false,
    "name": "mclaren-gcp-test-1",
    "networkDomain": {
      "id": 1
    },
    "noProxy": null,
    "resourcePermission": {},
    "scanNetwork": "off",
    "searchDomains": null,
    "site": {
      "id": 8
    },
    "tenants": [
      {
        "id": 1
      }
    ],
    "type": {
      "id": 38
    },
    "visibility": "private",
    "zone": {
      "id": 6
    },
    "zonePool": {
      "id": 85990 <<<<<<<<<<<<<<<<<<
    }
  }
}
```

Reflect this in the openapi spec.