### PR TITLE
Update format of resource IDs in role PUT and POST to int64

### DIFF
--- a/paths/api@roles.yaml
+++ b/paths/api@roles.yaml
@@ -145,6 +145,7 @@ post:
                     properties:
                       id:
                         type: integer
+                        format: int64
                         description: "`id` of the group (site)"
                       access:
                         type: string
@@ -173,6 +174,7 @@ post:
                     properties:
                       id:
                         type: integer
+                        format: int64
                         description: "`id` of the cloud (zone)"
                       access:
                         type: string
@@ -199,6 +201,7 @@ post:
                     properties:
                       id:
                         type: integer
+                        format: int64
                         description: "`id` of the instance type"
                       access:
                         type: string
@@ -222,6 +225,7 @@ post:
                     properties:
                       id:
                         type: integer
+                        format: int64
                         description: "`id` of the blueprint (appTemplate)"
                       access:
                         type: string
@@ -245,6 +249,7 @@ post:
                     properties:
                       id:
                         type: integer
+                        format: int64
                         description: "`id` of the catalog item type"
                       access:
                         type: string
@@ -295,6 +300,7 @@ post:
                     properties:
                       id:
                         type: integer
+                        format: int64
                         description: "`id` of the VDI pool"
                       access:
                         type: string
@@ -341,6 +347,7 @@ post:
                     properties:
                       id:
                         type: integer
+                        format: int64
                         description: "`id` of the task"
                       access:
                         type: string
@@ -364,6 +371,7 @@ post:
                     properties:
                       id:
                         type: integer
+                        format: int64
                         description: "`id` of the workflow (taskSet)"
                       access:
                         type: string

--- a/paths/api@roles@id.yaml
+++ b/paths/api@roles@id.yaml
@@ -102,6 +102,7 @@ put:
                     properties:
                       id:
                         type: integer
+                        format: int64
                         description: "`id` of the group (site)"
                       access:
                         type: string
@@ -129,6 +130,7 @@ put:
                     properties:
                       id:
                         type: integer
+                        format: int64
                         description: "`id` of the cloud (zone)"
                       access:
                         type: string
@@ -155,6 +157,7 @@ put:
                     properties:
                       id:
                         type: integer
+                        format: int64
                         description: "`id` of the instance type"
                       access:
                         type: string
@@ -178,6 +181,7 @@ put:
                     properties:
                       id:
                         type: integer
+                        format: int64
                         description: "`id` of the blueprint (appTemplate)"
                       access:
                         type: string
@@ -201,6 +205,7 @@ put:
                     properties:
                       id:
                         type: integer
+                        format: int64
                         description: "`id` of the catalog item type"
                       access:
                         type: string
@@ -251,6 +256,7 @@ put:
                     properties:
                       id:
                         type: integer
+                        format: int64
                         description: "`id` of the VDI pool"
                       access:
                         type: string
@@ -297,6 +303,7 @@ put:
                     properties:
                       id:
                         type: integer
+                        format: int64
                         description: "`id` of the task"
                       access:
                         type: string
@@ -320,6 +327,7 @@ put:
                     properties:
                       id:
                         type: integer
+                        format: int64
                         description: "`id` of the workflow (taskSet)"
                       access:
                         type: string


### PR DESCRIPTION
They were previously just `integer`.