### PR TITLE
Modify roles PUT to use code for persona

### DIFF
--- a/paths/api@roles@id.yaml
+++ b/paths/api@roles@id.yaml
@@ -224,7 +224,7 @@ put:
                   items:
                     type: object
                     required:
-                      - id
+                      - code
                       - access
                     properties:
                       code:


### PR DESCRIPTION
This should fix some sdk model generation. `id` was likely accidentally left in as required.
Matches POST behaviour now.