### PR TITLE
Add multitenant/multitenantLocked fields to Role PUT

### DIFF
--- a/paths/api@roles.yaml
+++ b/paths/api@roles.yaml
@@ -94,11 +94,11 @@ post:
                 multitenant:
                   type: boolean
                   default: false
-                  description: Multitenant roles are copied to all tenant accounts and kept in sync until a sub-tenant user modifies their copy of the role. *Only available to master tenant*
+                  description: Multitenant roles are copied to all tenant accounts and kept in sync until a sub-tenant user modifies their copy of the role. *Only available to master tenant, only applies to user roles*
                 multitenantLocked:
                   type: boolean
                   default: false
-                  description: Multitenant Locked, prevents sub-tenant users from modifying their copy of multitenant roles. *Only available to master tenant*
+                  description: Multitenant Locked, prevents sub-tenant users from modifying their copy of multitenant roles. *Only available to master tenant, only applies to user roles*
                 defaultPersona:
                   oneOf:
                     - type: string

--- a/paths/api@roles@id.yaml
+++ b/paths/api@roles@id.yaml
@@ -56,6 +56,12 @@ put:
                     - string
                     - 'null'
                   description: An optional override for the default landing page after login for a user.
+                multitenant:
+                  type: boolean
+                  description: Multitenant roles are copied to all tenant accounts and kept in sync until a sub-tenant user modifies their copy of the role. *Only available to master tenant, only applies to user roles*
+                multitenantLocked:
+                  type: boolean
+                  description: Multitenant Locked, prevents sub-tenant users from modifying their copy of multitenant roles. *Only available to master tenant, only applies to user roles*
                 defaultPersona:
                   oneOf:
                     - type: string


### PR DESCRIPTION
- Adds missing fields `multitenant` and `multitenantLocked` to PUT for roles.
- Updates description for POST and PUT to indicate that these only apply to `user` roles.
