### PR TITLE
Fix instance envs endpoint

### DIFF
--- a/components/schemas/instanceEnvs.yaml
+++ b/components/schemas/instanceEnvs.yaml
@@ -22,9 +22,9 @@ properties:
         - value
   readOnlyEnvs:
     type:
-      - array
+      - object
       - 'null'
-    items:
+    additionalProperties:
       type: object
       properties:
         export:
@@ -34,7 +34,9 @@ properties:
         name:
           type: string
         value:
-          type: string
+          type:
+            - string
+            - number
       required:
         - export
         - masked
@@ -42,10 +44,12 @@ properties:
         - value
   importedEnvs:
     type:
-      - array
+      - object
       - 'null'
-    items:
-      type: object
+    additionalProperties:
+      type: 
+        - object
+        - string
       properties:
         export:
           type: boolean
@@ -54,7 +58,9 @@ properties:
         name:
           type: string
         value:
-          type: string
+          type:
+            - string
+            - number
       required:
         - export
         - masked

--- a/paths/api@instances@id@envs.yaml
+++ b/paths/api@instances@id@envs.yaml
@@ -12,10 +12,7 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              instance:
-                $ref: ../components/schemas/instanceEnvs.yaml
+            $ref: ../components/schemas/instanceEnvs.yaml
           examples:
             Instance Env Response:
               value:


### PR DESCRIPTION
Response schema was defined with env vars being nested inside an instance object, this did not match the real API response.

Updates the response schema to change the types of `importedEnvs` and `readOnlyEnvs` from array to object to match the API.
Updates the type of `value` to acknowledge that the API may also return numbers in certain cases.