### PR TITLE
network switchId: add basic description

### DIFF
--- a/components/schemas/network.yaml
+++ b/components/schemas/network.yaml
@@ -204,6 +204,7 @@ properties:
     type:
       - string
       - 'null'
+    description: Network switch identifier
   fabricId:
     type:
       - string


### PR DESCRIPTION
This was present in create and update, but not get