### PR TITLE
Defining types for user access objects in user schema

### DIFF
--- a/components/schemas/user.yaml
+++ b/components/schemas/user.yaml
@@ -50,7 +50,9 @@ properties:
         authority:
           type: string
         description:
-          type: string
+          type:
+            - string
+            - 'null'
   account:
     type: object
     properties:
@@ -81,7 +83,9 @@ properties:
       - string
       - 'null'
   defaultPersona:
-    type: object
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -105,43 +109,146 @@ properties:
         type: array
         items:
           type: object
+          properties:
+            code:
+              type: string
+            name:
+              type: string
+            access:
+              type: string
+            subCategory:
+              type: string
       zones:
         type: array
         items:
           type: object
+          properties:
+            id:
+              type: integer
+              format: int64
+            name:
+              type: string
+            access:
+              type: string
       sites:
         type: array
         items:
           type: object
+          properties:
+            id:
+              type: integer
+              format: int64
+            name:
+              type: string
+            access:
+              type: string
       instanceTypes:
         type: array
         items:
           type: object
+          properties:
+            id:
+              type: integer
+              format: int64
+            code:
+              type: string
+            name:
+              type: string
+            access:
+              type: string
       appTemplates:
         type: array
         items:
           type: object
+          properties:
+            id:
+              type: integer
+              format: int64
+            name:
+              type: string
+            access:
+              type: string
       catalogItemTypes:
         type: array
         items:
           type: object
+          properties:
+            id:
+              type: integer
+              format: int64
+            name:
+              type: string
+            access:
+              type: string
       personas:
         type: array
         items:
           type: object
+          properties:
+            id:
+              type: integer
+              format: int64
+            code:
+              type: string
+            name:
+              type: string
+            access:
+              type: string
       vdiPools:
         type: array
         items:
           type: object
+          properties:
+            id:
+              type: integer
+              format: int64
+            name:
+              type: string
+            access:
+              type: string
       reportTypes:
         type: array
         items:
           type: object
+          properties:
+            id:
+              type: integer
+              format: int64
+            code:
+              type: string
+            name:
+              type: string
+            access:
+              type: string
       tasks:
         type: array
         items:
           type: object
+          properties:
+            id:
+              type: integer
+              format: int64
+            code:
+              type:
+                - string
+                - 'null'
+            name:
+              type: string
+            access:
+              type: string
       taskSets:
         type: array
         items:
           type: object
+          properties:
+            id:
+              type: integer
+              format: int64
+            code:
+              type:
+                - string
+                - 'null'
+            name:
+              type: string
+            access:
+              type: string


### PR DESCRIPTION
Defining types for each of the user access objects in the user schema. This will allow for more complete SDK and codespec generation for the Terraform user datasource.
- Added types for user access objects in user schema
- Updated roles description and default persona to be nullable after observing nulls in API responses.