### PR TITLE
Fix duplicate tenantCopies key in role schema

### DIFF
--- a/components/schemas/role.yaml
+++ b/components/schemas/role.yaml
@@ -84,20 +84,6 @@ properties:
             type: string
           name:
             type: string
-      tenantCopies:
-        type: array
-        description: Per-tenant copies of a multitenant master role (show only when applicable)
-        items:
-          type: object
-          properties:
-            tenantId:
-              type: integer
-              format: int64
-            roleId:
-              type: integer
-              format: int64
-            diverged:
-              type: boolean
       dateCreated:
         type: string
         format: date-time


### PR DESCRIPTION
Remove the second role.tenantCopies definition that breaks Redocly YAML parsing and openapi bundle.