### PR TITLE
Align support-bundles OpenAPI with public API

### DIFF
--- a/components/schemas/role.yaml
+++ b/components/schemas/role.yaml
@@ -84,20 +84,6 @@ properties:
             type: string
           name:
             type: string
-      tenantCopies:
-        type: array
-        description: Per-tenant copies of a multitenant master role (show only when applicable)
-        items:
-          type: object
-          properties:
-            tenantId:
-              type: integer
-              format: int64
-            roleId:
-              type: integer
-              format: int64
-            diverged:
-              type: boolean
       dateCreated:
         type: string
         format: date-time

--- a/components/schemas/supportBundle.yaml
+++ b/components/schemas/supportBundle.yaml
@@ -23,6 +23,20 @@ properties:
     type:
       - string
       - "null"
+  categories:
+    type:
+      - string
+      - "null"
+  startDate:
+    type:
+      - string
+      - "null"
+    format: date-time
+  endDate:
+    type:
+      - string
+      - "null"
+    format: date-time
   startedAt:
     type:
       - string

--- a/paths/api@support-bundles.yaml
+++ b/paths/api@support-bundles.yaml
@@ -11,6 +11,19 @@ get:
     - $ref: ../components/parameters/sort.yaml
     - $ref: ../components/parameters/direction.yaml
     - $ref: ../components/parameters/phrase.yaml
+    - name: status
+      in: query
+      description: Filter by support bundle generation status
+      schema:
+        type: string
+        enum:
+          - PENDING
+          - IN_PROGRESS
+          - CANCELLING
+          - CANCELLED
+          - COMPLETED
+          - WARNING
+          - FAILED
   responses:
     "200":
       description: Successful Request
@@ -32,7 +45,7 @@ get:
 post:
   summary: Generates a Support Bundle
   description: |
-    Generates a new support bundle. The bundle is created asynchronously — poll `GET /api/support-bundles/{id}` until `status` is `COMPLETED` or `FAILED`.
+    Generates a new support bundle. The bundle is created asynchronously — poll `GET /api/support-bundles/{id}` until `status` is terminal (`COMPLETED`, `WARNING`, `FAILED`, or `CANCELLED`).
 
     The request accepts an optional flat `contents` array describing which support bundle content entries to include. Each entry must provide either a content type `code` or `typeId`, and may optionally provide a `resourceId` for resource-backed content types.
 
@@ -56,6 +69,9 @@ post:
           required:
             - startDate
           properties:
+            name:
+              type: string
+              description: Optional unique name for the support bundle. When omitted, a name is generated automatically.
             storageProviderId:
               type: integer
               format: int64

--- a/paths/api@support-bundles@id@cancel.yaml
+++ b/paths/api@support-bundles@id@cancel.yaml
@@ -1,7 +1,7 @@
 post:
   summary: Cancel a Support Bundle
   description: |
-    Cancel a specific support bundle. If the bundle is PENDING it transitions immediately to CANCELLED. If IN_PROGRESS it transitions to CANCELLING and generation stops at the next checkpoint. Returns an error if the bundle is already in a terminal state (COMPLETED or FAILED). Calling cancel on an already CANCELLING or CANCELLED bundle is a no-op success.
+    Cancel a specific support bundle. If the bundle is PENDING it transitions immediately to CANCELLED. If IN_PROGRESS it transitions to CANCELLING and generation stops at the next checkpoint. Returns an error if the bundle is already in a terminal state (COMPLETED, WARNING, or FAILED). Calling cancel on an already CANCELLING or CANCELLED bundle is a no-op success.
   operationId: cancelSupportBundle
   tags:
     - Support Bundles

--- a/paths/api@support-bundles@id@download.yaml
+++ b/paths/api@support-bundles@id@download.yaml
@@ -3,7 +3,7 @@ get:
   description: |
     Downloads a specific support bundle as a file attachment.
 
-    The bundle must be in `COMPLETED` status before it can be downloaded. The returned archive type depends on the appliance support bundle archive setting.
+    The bundle must be in `COMPLETED` or `WARNING` status before it can be downloaded. The returned archive type depends on the appliance support bundle archive setting.
   operationId: downloadSupportBundle
   tags:
     - Support Bundles


### PR DESCRIPTION
## Summary
Align `/api/support-bundles` OpenAPI with the public support-bundles API from **MORPH-14713** (list/get/create/delete/download/cancel).

Controller/API is source of truth; no morpheus-ui changes in this PR.

## Changes
- Response schema: `categories`, `startDate`, `endDate`; keep useful field descriptions (`filePath`, `contentLength`, `contentType`, `storageProvider`)
- List: defaults (`max` 25, `sort` `dateCreated` desc), `phrase` on name, `status` filter
- Create: optional unique `name` (pattern + auto-name), date/content rules, options discovery notes
- Download: ready when `COMPLETED` or `WARNING`
- Cancel: status transitions including `WARNING` terminal / no-ops
- Note System Admin on all operations
- **CI:** remove duplicate `tenantCopies` key in `components/schemas/role.yaml` (pre-existing on `dev-9.1`; blocks Redocly bundle)
