### PR TITLE
Add missing instance service plan storage type attributes (MORPH-15864)

### DIFF
--- a/components/schemas/instanceServicePlanStorageType.yaml
+++ b/components/schemas/instanceServicePlanStorageType.yaml
@@ -80,3 +80,17 @@ properties:
     type:
       - string
       - 'null'
+  nameEditable:
+    type: boolean
+  planResizable:
+    type: boolean
+  hasISO:
+    type: boolean
+  noStorage:
+    type: boolean
+  multiAttachSupported:
+    type: boolean
+  hasActiveReplica:
+    type:
+      - boolean
+      - 'null'


### PR DESCRIPTION
## Summary

Adds six attributes that the API returns on instance service plan storage types but that `instanceServicePlanStorageType` did not declare:

| Attribute | Type |
|---|---|
| `nameEditable` | boolean |
| `planResizable` | boolean |
| `hasISO` | boolean |
| `noStorage` | boolean |
| `multiAttachSupported` | boolean |
| `hasActiveReplica` | boolean, nullable |

## Why

`GET /api/instances/service-plans` returns all six on every storage type, so they were being silently dropped into additional properties by generated clients.

## How the types were determined

All six are declared `Boolean` on the `StorageVolumeType` domain class. `hasActiveReplica` is additionally nullable: the API returns `null` for it on most storage types (observed on 5 of 6 on a test appliance), so it is typed as `[boolean, 'null']`.

The GORM `version` field also appears in responses but is deliberately **not** added — it is the implicit optimistic-locking counter rather than a meaningful API attribute, and it is always null in these responses.

## Related PRs

- Provider PR: https://github.com/HPE/terraform-provider-hpe/pull/1346

The provider PR consumes these attributes in the `hpe_morpheus_instance_disk_type` data source. It vendors its own generated SDK, so it is self-contained and **merges first**; this spec PR follows.

## Note for follow-up

`createDatastore` on the same schema is declared as a nullable string, but the API returns a JSON boolean. Generated clients therefore coerce it to the string `"0"`/`"1"`. It is left unchanged here to keep this PR to purely additive changes, but it is a genuine inaccuracy worth correcting.
