### PR TITLE
Fix incorrect OpenAPI contract for /api/health (MORPH-13813)

### DIFF
--- a/components/schemas/health.yaml
+++ b/components/schemas/health.yaml
@@ -1268,6 +1268,8 @@ properties:
   elastic:
     type: object
     properties:
+      noticeMessage:
+        type: string
       success:
         type: boolean
       status:
@@ -1376,3 +1378,11 @@ properties:
               format: int64
             status:
               type: string
+  storage:
+    type: object
+    additionalProperties: true
+  rda:
+    type:
+      - object
+      - "null"
+    additionalProperties: true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -477,6 +477,8 @@ paths:
     $ref: paths/api@guidance-settings.yaml
   /api/health:
     $ref: paths/api@health.yaml
+  /api/health/live:
+    $ref: paths/api@health@live.yaml
   /api/health/alarms:
     $ref: paths/api@health@alarms.yaml
   /api/health/alarms/acknowledge:

--- a/paths/api@health@alarms.yaml
+++ b/paths/api@health@alarms.yaml
@@ -21,7 +21,7 @@ get:
             allOf:
             - type: object
               properties:
-                alarm:
+                alarms:
                   type: array
                   items:
                     $ref: ../components/schemas/alarm.yaml

--- a/paths/api@health@alarms@acknowledge.yaml
+++ b/paths/api@health@alarms@acknowledge.yaml
@@ -1,6 +1,9 @@
 put:
   summary: Acknowledge Many Health Alarms
-  description: Acknowledge health alarms.
+  description: |
+    Acknowledge or unacknowledge one or more health alarms.
+    When `acknowledged` is omitted it defaults to `true`.
+    `all=true` acknowledges every active unacknowledged alarm.
   operationId: acknowledgeHealthAlarms
   tags:
     - Health
@@ -9,30 +12,28 @@ put:
       application/json:
         schema:
           type: object
-          required:
-            - alarm
           properties:
+            acknowledged:
+              type: boolean
+              description: |
+                `true` to acknowledge, `false` to unacknowledge. Defaults to `true`
+                when omitted. May also be sent as `alarm.acknowledged`.
+              default: true
             alarm:
               type: object
-              required:
-                - acknowledged
               properties:
-                acknowledged: 
+                acknowledged:
                   type: boolean
-                  description: Pass `true` to ackowledge an alarm, or pass `false` to unacknowledge it.
-                ids:
-                  type: array
-                  description: Array of Alarm ID(s)to be updated.
-                  default: []
-                  items:
-                    type: integer
-                    format: int64
-                all:
-                  type: boolean
-                  description: | 
-                    Pass `true` to update all alarms instead of passing ids.
-                    This will update any active alarm that is not already acknowledged.
-                  default: false
+            ids:
+              type: array
+              description: Alarm IDs to update
+              items:
+                type: integer
+                format: int64
+            all:
+              type: boolean
+              description: When true, acknowledge all active unacknowledged alarms
+              default: false
   responses:
     '200':
       description: Successful Request

--- a/paths/api@health@alarms@id@acknowledge.yaml
+++ b/paths/api@health@alarms@id@acknowledge.yaml
@@ -1,6 +1,8 @@
 put:
   summary: Acknowledge a Health Alarm
-  description: Acknowledge a specific health alarm.
+  description: |
+    Acknowledge or unacknowledge a specific health alarm.
+    When `acknowledged` is omitted it defaults to `true`.
   operationId: acknowledgeHealthAlarm
   tags:
     - Health
@@ -11,17 +13,18 @@ put:
       application/json:
         schema:
           type: object
-          required:
-            - alarm
           properties:
+            acknowledged:
+              type: boolean
+              description: |
+                `true` to acknowledge, `false` to unacknowledge. Defaults to `true`
+                when omitted. May also be sent as `alarm.acknowledged`.
+              default: true
             alarm:
               type: object
-              required:
-                - acknowledged
               properties:
-                acknowledged: 
+                acknowledged:
                   type: boolean
-                  description: Pass `true` to ackowledge an alarm, or pass `false` to unacknowledge it.
   responses:
     '200':
       description: Successful Request

--- a/paths/api@health@live.yaml
+++ b/paths/api@health@live.yaml
@@ -1,7 +1,9 @@
 get:
-  summary: Retrieves Appliance Health
-  description: This endpoint retrieves health info about the appliance such as cpu, memory and database usage. Elasticsearch statistics and queue usage are also returned.
-  operationId: listHealth
+  summary: Retrieves Live Appliance Health
+  description: |
+    Collects appliance health on demand (not from cache). Response shape matches
+    `GET /api/health`. Elasticsearch includes the full index list, not only problem indices.
+  operationId: getLiveHealth
   tags:
     - Health
   responses:


### PR DESCRIPTION
## Summary
Minimal OpenAPI corrections for public Health APIs after the UI migration to `/api/health` (MORPH-13813). Contract fixes only — no docs polish or extra surface area.

## Changes
- Register missing `GET /api/health/live` (used by the UI for on-demand stats)
- Drop incorrect `meta` wrapper on `GET /api/health` (response is `{ health }` only)
- Add missing health response fields: `storage`, `rda`, elastic `noticeMessage`
- Fix alarms list response key: `alarm` → `alarms`
- Fix acknowledge request bodies to match the API (top-level `acknowledged` / `ids` / `all`; nested `alarm.acknowledged` still allowed)
