### PR TITLE
Policies: fix incorrect OpenAPI contract

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -940,6 +940,8 @@ paths:
     $ref: paths/api@zones@id@policies@id.yaml
   /api/policy-types:
     $ref: paths/api@policy-types.yaml
+  /api/policy-types/{policyTypeId}:
+    $ref: paths/api@policy-types@id.yaml
   /api/power-schedules:
     $ref: paths/api@power-schedules.yaml
   /api/power-schedules/{id}:

--- a/paths/api@groups@id@policies.yaml
+++ b/paths/api@groups@id@policies.yaml
@@ -26,6 +26,10 @@ get:
                   type: array
                   items:
                     $ref: ../components/schemas/policy.yaml
+                policyCount:
+                  type: integer
+                  format: int64
+                  description: Total number of policies matching the request
             - $ref: ../components/schemas/meta.yaml
           examples:
             Policies Response:
@@ -39,7 +43,7 @@ post:
   summary: Creates a Policy for a Group
   description: |
     Creates a policy for a Group.
-  operationId: addPoliciesGroup
+  operationId: addPolicyGroup
   parameters:
     - $ref: ../components/parameters/groupId-path.yaml
   tags:

--- a/paths/api@groups@id@policies@id.yaml
+++ b/paths/api@groups@id@policies@id.yaml
@@ -2,7 +2,7 @@ get:
   summary: Retrieves a Specific Policy for a Group
   description: |
     Retrieves a specific policy for a Group.
-  operationId: getPoliciesGroup
+  operationId: getPolicyGroup
   tags:
     - Policies
   parameters:
@@ -127,7 +127,7 @@ put:
   summary: Updates a Policy for a Group
   description: |
     Updates a policy for a Group.
-  operationId: updatePoliciesGroup
+  operationId: updatePolicyGroup
   tags:
     - Policies
   parameters:
@@ -263,7 +263,7 @@ delete:
   summary: Deletes a Policy for a Group
   description: |
     Deletes a specified policy for a Group.
-  operationId: removePoliciesGroup
+  operationId: removePolicyGroup
   tags:
     - Policies
   parameters:

--- a/paths/api@policies.yaml
+++ b/paths/api@policies.yaml
@@ -25,6 +25,10 @@ get:
                   type: array
                   items:
                     $ref: ../components/schemas/policy.yaml
+                policyCount:
+                  type: integer
+                  format: int64
+                  description: Total number of policies matching the request
             - $ref: ../components/schemas/meta.yaml
           examples:
             Policies Response:
@@ -38,7 +42,7 @@ post:
   summary: Creates a Policy
   description: |
     Creates a policy.
-  operationId: addPolicies
+  operationId: addPolicy
   tags:
     - Policies
   requestBody:

--- a/paths/api@policies@id.yaml
+++ b/paths/api@policies@id.yaml
@@ -2,7 +2,7 @@ get:
   summary: Retrieves a Specific Policy
   description: |
     Retrieves a specific policy.
-  operationId: getPolicies
+  operationId: getPolicy
   tags:
     - Policies
   parameters:
@@ -126,7 +126,7 @@ put:
   summary: Updates a Policy
   description: |
     Updates a policy.
-  operationId: updatePolicies
+  operationId: updatePolicy
   tags:
     - Policies
   parameters:
@@ -261,7 +261,7 @@ delete:
   summary: Deletes a Policy
   description: |
     Deletes a specified policy.
-  operationId: removePolicies
+  operationId: removePolicy
   tags:
     - Policies
   parameters:

--- a/paths/api@policy-types@id.yaml
+++ b/paths/api@policy-types@id.yaml
@@ -1,0 +1,34 @@
+get:
+  summary: Retrieves a Specific Policy Type
+  description: |
+    Retrieves a specific policy type.
+  operationId: getPolicyType
+  tags:
+    - Policies
+  parameters:
+    - name: policyTypeId
+      in: path
+      description: Morpheus ID of the policy type
+      required: true
+      schema:
+        type: integer
+        format: int64
+      example: 1
+  responses:
+    '200':
+      description: Successful Request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              policyType:
+                $ref: ../components/schemas/policyType.yaml
+          examples:
+            Policy Type Response:
+              value:
+                $ref: ../components/examples/policyType.json
+    '4XX':
+      $ref: ../components/responses/4xx.yaml
+    '5XX':
+      $ref: ../components/responses/5xx.yaml

--- a/paths/api@zones@id@policies.yaml
+++ b/paths/api@zones@id@policies.yaml
@@ -26,6 +26,10 @@ get:
                   type: array
                   items:
                     $ref: ../components/schemas/policy.yaml
+                policyCount:
+                  type: integer
+                  format: int64
+                  description: Total number of policies matching the request
             - $ref: ../components/schemas/meta.yaml
           examples:
             Policies Response:
@@ -39,7 +43,7 @@ post:
   summary: Creates a Policy for a Cloud
   description: |
     Creates a policy for a Cloud.
-  operationId: addPoliciesCloud
+  operationId: addPolicyCloud
   parameters:
     - $ref: ../components/parameters/cloudId-path.yaml
   tags:

--- a/paths/api@zones@id@policies@id.yaml
+++ b/paths/api@zones@id@policies@id.yaml
@@ -2,7 +2,7 @@ get:
   summary: Retrieves a Specific Policy for a Cloud
   description: |
     Retrieves a specific policy for a Cloud.
-  operationId: getPoliciesCloud
+  operationId: getPolicyCloud
   tags:
     - Policies
   parameters:
@@ -127,7 +127,7 @@ put:
   summary: Updates a Policy for a Cloud
   description: |
     Updates a policy for a Cloud.
-  operationId: updatePoliciesCloud
+  operationId: updatePolicyCloud
   tags:
     - Policies
   parameters:
@@ -263,7 +263,7 @@ delete:
   summary: Deletes a Policy for a Cloud
   description: |
     Deletes a specified policy for a Cloud.
-  operationId: removePoliciesCloud
+  operationId: removePolicyCloud
   tags:
     - Policies
   parameters:


### PR DESCRIPTION
## Summary
Minimal wrong-spec fixes for Policies / Policy Types against the live API.

- Register missing `GET /api/policy-types/{policyTypeId}` (`getPolicyType`)
- Correct plural operationIds on policy CRUD to singular (`getPolicy`, `addPolicy`, `updatePolicy`, `removePolicy`, plus group/cloud variants)
- Document `policyCount` on policy list responses (global, group, cloud)
