### PR TITLE
Environments: fix incorrect OpenAPI contract

### DIFF
--- a/paths/api@environments.yaml
+++ b/paths/api@environments.yaml
@@ -12,6 +12,7 @@ get:
     - $ref: ../components/parameters/phrase.yaml
     - $ref: ../components/parameters/name.yaml
     - $ref: ../components/parameters/code.yaml
+    - $ref: ../components/parameters/active.yaml
   responses:
     '200':
       description: Array of Environments
@@ -37,7 +38,7 @@ get:
 post:
   summary: Create a New Environment
   description: Create a new environment.
-  operationId: addEnvironments
+  operationId: addEnvironment
   tags:
     - Environments
   requestBody:
@@ -76,6 +77,10 @@ post:
                   format: int64
                   description: Sort order
                   default: 0
+                active:
+                  type: boolean
+                  description: Set to false to create the environment inactive
+                  example: true
   responses:
     '200':
       description: Environment Object

--- a/paths/api@environments@id.yaml
+++ b/paths/api@environments@id.yaml
@@ -1,7 +1,7 @@
 get:
   summary: Get a Specific Environment
   description: This endpoint will retrieve a specific environment by id.
-  operationId: getEnvironments
+  operationId: getEnvironment
   tags:
     - Environments
   parameters:
@@ -27,7 +27,7 @@ get:
 put:
   summary: Update Environment
   description: Update an existing environment.
-  operationId: updateEnvironments
+  operationId: updateEnvironment
   tags:
     - Environments
   parameters:
@@ -88,7 +88,7 @@ put:
 delete:
   summary: Delete a Specific Environment
   description: Delete an existing environment.
-  operationId: deleteEnvironments
+  operationId: deleteEnvironment
   tags:
     - Environments
   parameters:

--- a/paths/api@environments@id@toggle-active.yaml
+++ b/paths/api@environments@id@toggle-active.yaml
@@ -1,7 +1,36 @@
+post:
+  summary: Toggle Active State of Environment
+  description: Toggle Active State of Environment. Default is to toggle the current value.
+  operationId: updateEnvironmentActivePost
+  tags:
+    - Environments
+  parameters:
+  - $ref: ../components/parameters/id-path.yaml
+  - $ref: ../components/parameters/active.yaml
+  responses:
+    '200':
+      description: Environment Object
+      content:
+        application/json:
+          schema:
+            allOf:
+            - type: object
+              properties:
+                environment:
+                  $ref: ../components/schemas/environment.yaml
+            - $ref: ../components/schemas/200-success.yaml
+          examples:
+            Update Environment Response:
+              value:
+                $ref: ../components/examples/environmentSuccess.json
+    '4XX':
+      $ref: ../components/responses/4xx.yaml
+    '5XX':
+      $ref: ../components/responses/5xx.yaml
 put:
   summary: Toggle Active State of Environment
   description: Toggle Active State of Environment. Default is to toggle the current value.
-  operationId: updateEnvironmentsActive
+  operationId: updateEnvironmentActive
   tags:
     - Environments
   parameters:


### PR DESCRIPTION
## Summary
Minimal wrong-spec fixes for Environments against the live API.

- Correct plural operationIds to singular (`getEnvironment`, `addEnvironment`, `updateEnvironment`, `deleteEnvironment`, `updateEnvironmentActive`)
- Document `active` list query filter (live `params.active`)
- Document optional `active` on create body (service binds it)
- Register `POST /api/environments/{id}/toggle-active` alongside existing `PUT` (both mapped live; UI uses PUT)
