### PR TITLE
Provisioning-settings: fix incorrect OpenAPI contract

### DIFF
--- a/components/schemas/provisioningSettings.yaml
+++ b/components/schemas/provisioningSettings.yaml
@@ -52,3 +52,45 @@ properties:
         format: int64
       name:
         type: string
+  showConsoleKeyboardSettings:
+    type: boolean
+    description: Whether console keyboard settings are shown
+  cloudInitPasswordHash:
+    type:
+      - string
+      - 'null'
+    description: Hash of the cloud-init password
+  windowsPasswordHash:
+    type:
+      - string
+      - 'null'
+    description: Hash of the Windows administrator password
+  pxeRootPasswordHash:
+    type:
+      - string
+      - 'null'
+    description: Hash of the PXE root password
+  enableCatalog:
+    type: boolean
+    description: Whether catalog provisioning is enabled
+  enableApps:
+    type: boolean
+    description: Whether apps provisioning is enabled
+  enableInstances:
+    type: boolean
+    description: Whether instances provisioning is enabled
+  provisioningOrder:
+    type:
+      - string
+      - 'null'
+    description: Provisioning navigation order (dash-separated)
+  terraformMode:
+    type:
+      - string
+      - 'null'
+    description: Terraform execution mode
+  terraformVersion:
+    type:
+      - string
+      - 'null'
+    description: Terraform version

--- a/components/schemas/provisioningSettingsUpdate.yaml
+++ b/components/schemas/provisioningSettingsUpdate.yaml
@@ -54,3 +54,24 @@ properties:
         type: integer
         format: int64
         description: Default blueprint type ID
+  consoleKeyboardSettings:
+    type: boolean
+    description: Enable or disable console keyboard settings (stored setting name)
+  enableCatalog:
+    type: boolean
+    description: Enable or disable catalog provisioning
+  enableApps:
+    type: boolean
+    description: Enable or disable apps provisioning
+  enableInstances:
+    type: boolean
+    description: Enable or disable instances provisioning
+  provisioningOrder:
+    type: string
+    description: Provisioning navigation order (dash-separated values)
+  terraformMode:
+    type: string
+    description: Terraform execution mode
+  terraformVersion:
+    type: string
+    description: Terraform version

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -981,6 +981,8 @@ paths:
     $ref: paths/api@provisioning-licenses@id@reservations.yaml
   /api/provisioning-settings:
     $ref: paths/api@provisioning-settings.yaml
+  /api/provisioning-settings/template-types:
+    $ref: paths/api@provisioning-settings@template-types.yaml
   /api/public-archives/download/{bucket}/{filepath}:
     $ref: paths/api@public-archives@download@id@path.yaml
   /api/public-archives/link:

--- a/paths/api@provisioning-settings.yaml
+++ b/paths/api@provisioning-settings.yaml
@@ -1,7 +1,7 @@
 get:
   summary: Get Provisioning Settings
   description: This endpoint retrieves provisioning settings.
-  operationId: listProvisioningSettings
+  operationId: getProvisioningSettings
   tags:
     - Provisioning Settings
   responses:
@@ -47,7 +47,17 @@ put:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/200-success.yaml
+            allOf:
+            - $ref: ../components/schemas/200-success.yaml
+            - type: object
+              properties:
+                msg:
+                  type: string
+                errors:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: Field validation errors when success is false
           examples:
             Successful Response:
               value:

--- a/paths/api@provisioning-settings@template-types.yaml
+++ b/paths/api@provisioning-settings@template-types.yaml
@@ -1,0 +1,38 @@
+get:
+  summary: List Template Types
+  description: |
+    Retrieves blueprint template types available for the default template type setting.
+  operationId: listProvisioningSettingsTemplateTypes
+  tags:
+    - Provisioning Settings
+  responses:
+    '200':
+      description: Successful Response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              templateTypes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                      format: int64
+                    name:
+                      type: string
+                    code:
+                      type: string
+          examples:
+            Successful Response:
+              value:
+                templateTypes:
+                  - id: 1
+                    name: Morpheus
+                    code: morpheus
+    '4XX':
+      $ref: ../components/responses/4xx.yaml
+    '5XX':
+      $ref: ../components/responses/5xx.yaml


### PR DESCRIPTION
## Summary
Minimal wrong-spec fixes for Provisioning Settings against the live API.

- `listProvisioningSettings` → `getProvisioningSettings`
- Document missing response fields from `provisioning.gson` (`showConsoleKeyboardSettings`, password hashes, catalog/apps/instances toggles, `provisioningOrder`, terraform fields)
- Document matching writable update fields (`consoleKeyboardSettings`, nav toggles/order, terraform)
- Update response may include `msg` / `errors` (shared save view)
- Register missing `GET /api/provisioning-settings/template-types`
