### PR TITLE
Fix incorrect log-settings OpenAPI contract

### DIFF
--- a/components/examples/logSettings.json
+++ b/components/examples/logSettings.json
@@ -3,6 +3,7 @@
         "enabled": true,
         "retentionDays": "7",
         "minimumLogLevel": null,
-        "syslogRules": []
+        "syslogRules": [],
+        "integrations": []
     }
 }

--- a/components/schemas/logSettings.yaml
+++ b/components/schemas/logSettings.yaml
@@ -3,7 +3,10 @@ properties:
   enabled:
     type: boolean
   retentionDays:
-    type: string
+    description: Log retention period in days
+    oneOf:
+      - type: string
+      - type: integer
   minimumLogLevel:
     type:
       - string
@@ -20,6 +23,34 @@ properties:
       - 'null'
     items:
       type: object
-    example:
-      - name: foo
-        rule: "*.* @@localhost:4567"
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Syslog rule ID
+        name:
+          type: string
+          description: Syslog rule name
+        rule:
+          type: string
+          description: Syslog rule configuration
+  integrations:
+    type: array
+    description: Log forwarding integrations (product-dependent; may be empty)
+    items:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Integration type name
+        enabled:
+          type: boolean
+        host:
+          type:
+            - string
+            - 'null'
+        port:
+          type:
+            - string
+            - 'null'
+            - integer

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -768,6 +768,8 @@ paths:
     $ref: paths/api@log-settings@syslog-rules.yaml
   /api/log-settings/syslog-rules/{id}:
     $ref: paths/api@log-settings@syslog-rules@id.yaml
+  /api/log-settings/integrations/{name}:
+    $ref: paths/api@log-settings@integrations@name.yaml
 
   /api/logs:
     $ref: paths/api@logs.yaml

--- a/paths/api@log-settings.yaml
+++ b/paths/api@log-settings.yaml
@@ -1,7 +1,7 @@
 get:
-  summary: List All Log Settings
+  summary: Get Log Settings
   description: This endpoint retrieves log settings.
-  operationId: listLogSettings
+  operationId: getLogSettings
   tags:
     - Log Settings
   responses:
@@ -32,10 +32,10 @@ put:
     content:
       application/json:
         schema:
-            type: object
-            properties:
-              logSettings:
-                $ref: ../components/schemas/logSettings.yaml
+          type: object
+          properties:
+            logSettings:
+              $ref: ../components/schemas/logSettings.yaml
   responses:
     '200':
       description: Successful Response
@@ -44,6 +44,15 @@ put:
           schema:
             allOf:
               - $ref: ../components/schemas/200-success.yaml
+              - type: object
+                properties:
+                  msg:
+                    type: string
+                  errors:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: Field validation errors when success is false
           examples:
             Update Log Settings Response:
               value:

--- a/paths/api@log-settings@integrations@name.yaml
+++ b/paths/api@log-settings@integrations@name.yaml
@@ -1,0 +1,95 @@
+put:
+  summary: Update a Log Settings Integration
+  description: Update a log forwarding integration by name.
+  operationId: updateLogSettingsIntegration
+  tags:
+    - Log Settings
+  parameters:
+    - name: name
+      in: path
+      required: true
+      description: Integration type name
+      schema:
+        type: string
+      example: splunk
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - integration
+          properties:
+            integration:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                host:
+                  type: string
+                port:
+                  oneOf:
+                    - type: string
+                    - type: integer
+  responses:
+    '200':
+      description: Successful Response
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: ../components/schemas/200-success.yaml
+              - type: object
+                properties:
+                  msg:
+                    type: string
+                  errors:
+                    type: object
+                    additionalProperties:
+                      type: string
+          examples:
+            Successful Response:
+              value:
+                $ref: ../components/examples/success.json
+    '4XX':
+      $ref: ../components/responses/4xx.yaml
+    '5XX':
+      $ref: ../components/responses/5xx.yaml
+delete:
+  summary: Delete a Log Settings Integration
+  description: Delete a log forwarding integration by name.
+  operationId: deleteLogSettingsIntegration
+  tags:
+    - Log Settings
+  parameters:
+    - name: name
+      in: path
+      required: true
+      description: Integration type name
+      schema:
+        type: string
+      example: splunk
+  responses:
+    '200':
+      description: Successful Response
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: ../components/schemas/200-success.yaml
+              - type: object
+                properties:
+                  msg:
+                    type: string
+                  errors:
+                    type: object
+                    additionalProperties:
+                      type: string
+          examples:
+            Successful Response:
+              value:
+                $ref: ../components/examples/success.json
+    '4XX':
+      $ref: ../components/responses/4xx.yaml
+    '5XX':
+      $ref: ../components/responses/5xx.yaml

--- a/paths/api@log-settings@syslog-rules.yaml
+++ b/paths/api@log-settings@syslog-rules.yaml
@@ -33,7 +33,16 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/200-success.yaml
+            allOf:
+              - $ref: ../components/schemas/200-success.yaml
+              - type: object
+                properties:
+                  msg:
+                    type: string
+                  errors:
+                    type: object
+                    additionalProperties:
+                      type: string
           examples:
             Successful Response:
               value:

--- a/paths/api@log-settings@syslog-rules@id.yaml
+++ b/paths/api@log-settings@syslog-rules@id.yaml
@@ -1,6 +1,6 @@
 delete:
   summary: Delete a Specific Syslog Rule
-  description: Will delete the syslog rule matching the specified name.
+  description: Will delete the syslog rule matching the specified id.
   operationId: deleteLogSettingsSyslogRules
   tags:
     - Log Settings
@@ -12,7 +12,16 @@ delete:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/200-success.yaml
+            allOf:
+              - $ref: ../components/schemas/200-success.yaml
+              - type: object
+                properties:
+                  msg:
+                    type: string
+                  errors:
+                    type: object
+                    additionalProperties:
+                      type: string
           examples:
             Delete Syslog Rule Response:
               value:


### PR DESCRIPTION
Minimal wrong-spec fixes for Log Settings against the live API.

- Rename GET operationId `listLogSettings` → `getLogSettings` (single settings object)
- Document `syslogRules[]` item shape (`id`, `name`, `rule`) and `integrations[]` on GET
- Document update / syslog-rule / delete responses with shared save `msg` / `errors`
- Add missing live routes `PUT|DELETE /api/log-settings/integrations/{name}`
