### PR TITLE
Restore stable operationIds for docs deep-links

### DIFF
--- a/paths/api@environments.yaml
+++ b/paths/api@environments.yaml
@@ -38,7 +38,7 @@ get:
 post:
   summary: Create a New Environment
   description: Create a new environment.
-  operationId: addEnvironment
+  operationId: addEnvironments
   tags:
     - Environments
   requestBody:

--- a/paths/api@environments@id.yaml
+++ b/paths/api@environments@id.yaml
@@ -1,7 +1,7 @@
 get:
   summary: Get a Specific Environment
   description: This endpoint will retrieve a specific environment by id.
-  operationId: getEnvironment
+  operationId: getEnvironments
   tags:
     - Environments
   parameters:
@@ -27,7 +27,7 @@ get:
 put:
   summary: Update Environment
   description: Update an existing environment.
-  operationId: updateEnvironment
+  operationId: updateEnvironments
   tags:
     - Environments
   parameters:
@@ -88,7 +88,7 @@ put:
 delete:
   summary: Delete a Specific Environment
   description: Delete an existing environment.
-  operationId: deleteEnvironment
+  operationId: deleteEnvironments
   tags:
     - Environments
   parameters:

--- a/paths/api@environments@id@toggle-active.yaml
+++ b/paths/api@environments@id@toggle-active.yaml
@@ -30,7 +30,7 @@ post:
 put:
   summary: Toggle Active State of Environment
   description: Toggle Active State of Environment. Default is to toggle the current value.
-  operationId: updateEnvironmentActive
+  operationId: updateEnvironmentsActive
   tags:
     - Environments
   parameters:

--- a/paths/api@groups@id@policies.yaml
+++ b/paths/api@groups@id@policies.yaml
@@ -43,7 +43,7 @@ post:
   summary: Creates a Policy for a Group
   description: |
     Creates a policy for a Group.
-  operationId: addPolicyGroup
+  operationId: addPoliciesGroup
   parameters:
     - $ref: ../components/parameters/groupId-path.yaml
   tags:

--- a/paths/api@groups@id@policies@id.yaml
+++ b/paths/api@groups@id@policies@id.yaml
@@ -2,7 +2,7 @@ get:
   summary: Retrieves a Specific Policy for a Group
   description: |
     Retrieves a specific policy for a Group.
-  operationId: getPolicyGroup
+  operationId: getPoliciesGroup
   tags:
     - Policies
   parameters:
@@ -127,7 +127,7 @@ put:
   summary: Updates a Policy for a Group
   description: |
     Updates a policy for a Group.
-  operationId: updatePolicyGroup
+  operationId: updatePoliciesGroup
   tags:
     - Policies
   parameters:
@@ -263,7 +263,7 @@ delete:
   summary: Deletes a Policy for a Group
   description: |
     Deletes a specified policy for a Group.
-  operationId: removePolicyGroup
+  operationId: removePoliciesGroup
   tags:
     - Policies
   parameters:

--- a/paths/api@log-settings.yaml
+++ b/paths/api@log-settings.yaml
@@ -1,7 +1,7 @@
 get:
   summary: Get Log Settings
   description: This endpoint retrieves log settings.
-  operationId: getLogSettings
+  operationId: listLogSettings
   tags:
     - Log Settings
   responses:

--- a/paths/api@policies.yaml
+++ b/paths/api@policies.yaml
@@ -42,7 +42,7 @@ post:
   summary: Creates a Policy
   description: |
     Creates a policy.
-  operationId: addPolicy
+  operationId: addPolicies
   tags:
     - Policies
   requestBody:

--- a/paths/api@policies@id.yaml
+++ b/paths/api@policies@id.yaml
@@ -2,7 +2,7 @@ get:
   summary: Retrieves a Specific Policy
   description: |
     Retrieves a specific policy.
-  operationId: getPolicy
+  operationId: getPolicies
   tags:
     - Policies
   parameters:
@@ -126,7 +126,7 @@ put:
   summary: Updates a Policy
   description: |
     Updates a policy.
-  operationId: updatePolicy
+  operationId: updatePolicies
   tags:
     - Policies
   parameters:
@@ -261,7 +261,7 @@ delete:
   summary: Deletes a Policy
   description: |
     Deletes a specified policy.
-  operationId: removePolicy
+  operationId: removePolicies
   tags:
     - Policies
   parameters:

--- a/paths/api@provisioning-settings.yaml
+++ b/paths/api@provisioning-settings.yaml
@@ -1,7 +1,7 @@
 get:
   summary: Get Provisioning Settings
   description: This endpoint retrieves provisioning settings.
-  operationId: getProvisioningSettings
+  operationId: listProvisioningSettings
   tags:
     - Provisioning Settings
   responses:

--- a/paths/api@zones@id@policies.yaml
+++ b/paths/api@zones@id@policies.yaml
@@ -43,7 +43,7 @@ post:
   summary: Creates a Policy for a Cloud
   description: |
     Creates a policy for a Cloud.
-  operationId: addPolicyCloud
+  operationId: addPoliciesCloud
   parameters:
     - $ref: ../components/parameters/cloudId-path.yaml
   tags:

--- a/paths/api@zones@id@policies@id.yaml
+++ b/paths/api@zones@id@policies@id.yaml
@@ -2,7 +2,7 @@ get:
   summary: Retrieves a Specific Policy for a Cloud
   description: |
     Retrieves a specific policy for a Cloud.
-  operationId: getPolicyCloud
+  operationId: getPoliciesCloud
   tags:
     - Policies
   parameters:
@@ -127,7 +127,7 @@ put:
   summary: Updates a Policy for a Cloud
   description: |
     Updates a policy for a Cloud.
-  operationId: updatePolicyCloud
+  operationId: updatePoliciesCloud
   tags:
     - Policies
   parameters:
@@ -263,7 +263,7 @@ delete:
   summary: Deletes a Policy for a Cloud
   description: |
     Deletes a specified policy for a Cloud.
-  operationId: removePolicyCloud
+  operationId: removePoliciesCloud
   tags:
     - Policies
   parameters:


### PR DESCRIPTION
Addresses the operationId stability feedback from [PR #338](https://github.com/HewlettPackard/morpheus-openapi/pull/338) (and the same issue in later contract PRs).

We do not rename existing `operationId`s because that breaks old docs URLs on https://apidocs.morpheusdata.com.

## Scope (restore only)
Restores pre-rename `operationId`s introduced by:

| PR | Branch / change | Restored examples |
|---|---|---|
| #338 | `fix/openapi-policies` | `getPolicy` → `getPolicies`, `addPolicy` → `addPolicies`, group/cloud variants |
| #339 | `fix/openapi-environments` | `getEnvironment` → `getEnvironments`, etc.; PUT toggle → `updateEnvironmentsActive` |
| #340 | `fix/openapi-provisioning-settings` | `getProvisioningSettings` → `listProvisioningSettings` |
| #341 | `fix/openapi-log-settings` | `getLogSettings` → `listLogSettings` |
