### PR TITLE
Email-templates: Fix incorrect OpenAPI contract 

### DIFF
--- a/components/examples/emailTemplateCreateSuccess.json
+++ b/components/examples/emailTemplateCreateSuccess.json
@@ -3,12 +3,12 @@
     "emailTemplate": {
         "id": 45,
         "name": "Confirm Email on Register Template",
-        "account": {
+        "owner": {
             "id": 1,
             "name": "Morpheus QA"
         },
         "code": "confirmEmail",
         "template": "this is a test",
-        "enabled": true
+        "accounts": []
     }
 }

--- a/components/schemas/emailTemplateWrite.yaml
+++ b/components/schemas/emailTemplateWrite.yaml
@@ -1,0 +1,14 @@
+type: object
+properties:
+  code:
+    type: string
+    description: |
+      Template type code. Required on create; not changed on update.
+  template:
+    type: string
+    description: |
+      Email body (Handlebars).
+  accounts:
+    type: string
+    description: |
+      Comma-separated account IDs that may use this template.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -169,6 +169,8 @@ paths:
     $ref: paths/api@email-templates.yaml
   /api/email-templates/{id}:
     $ref: paths/api@email-templates@id.yaml
+  /api/email-templates/types:
+    $ref: paths/api@email-templates@types.yaml
   
   /api/monitoring/alerts:
     $ref: paths/api@monitoring@alerts.yaml

--- a/paths/api@email-templates.yaml
+++ b/paths/api@email-templates.yaml
@@ -47,7 +47,7 @@ post:
           type: object
           properties:
             emailTemplate:
-              $ref: ../components/schemas/emailTemplate.yaml
+              $ref: ../components/schemas/emailTemplateWrite.yaml
   responses: 
     '200':
       description: Successful Request

--- a/paths/api@email-templates@id.yaml
+++ b/paths/api@email-templates@id.yaml
@@ -42,8 +42,8 @@ put:
           allOf:
           - type: object
             properties:
-              policy:
-                $ref: ../components/schemas/emailTemplate.yaml
+              emailTemplate:
+                $ref: ../components/schemas/emailTemplateWrite.yaml
   responses:
     '200':
       description: Successful Request

--- a/paths/api@email-templates@types.yaml
+++ b/paths/api@email-templates@types.yaml
@@ -1,0 +1,37 @@
+get:
+  summary: List email template types
+  description: |
+    Lists available system email template types for create.
+  operationId: listEmailTemplateTypes
+  tags:
+    - Email Templates
+  responses:
+    '200':
+      description: Successful Request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              success:
+                type: boolean
+              types:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+          examples:
+            Email Template Types Response:
+              value:
+                success: true
+                types:
+                  - name: Instance Shutdown Template
+                    value: instanceShutdown
+    '4XX':
+      $ref: ../components/responses/4xx.yaml
+    '5XX':
+      $ref: ../components/responses/5xx.yaml


### PR DESCRIPTION
Contract fixes for `/api/email-templates` against Grails + React UI.

## Changes
- PUT request wrapper was incorrectly `policy`; corrected to `emailTemplate`
- Request body uses write fields (`code`, `template`, comma-separated `accounts`) instead of the full read schema
- Document `GET /api/email-templates/types` (UI loads type dropdown from this)
- Create success example fields aligned with gson (`owner`/`accounts`)
