### PR TITLE
Whitelabel-settings: Fix incorrect OpenAPI contract

### DIFF
--- a/components/examples/whitelabelSettings.json
+++ b/components/examples/whitelabelSettings.json
@@ -29,6 +29,13 @@
         "label": "Help",
         "labelCode": "help"
       }
-    ]
+    ],
+    "account": {
+      "id": 1,
+      "name": "Root"
+    },
+    "supportsThemes": false,
+    "securityBanner": "",
+    "externalLegalText": ""
   }
 }

--- a/components/schemas/whitelabelSettings.yaml
+++ b/components/schemas/whitelabelSettings.yaml
@@ -1,11 +1,25 @@
 type: object
 properties: 
+  account:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
   enabled: 
     type: boolean
   applianceName: 
     type: string
   disableSupportMenu: 
     type: boolean
+  supportsThemes:
+    type: boolean
+  securityBanner:
+    type: string
+  externalLegalText:
+    type: string
   headerLogo: 
     type: string
   footerLogo: 

--- a/components/schemas/whitelabelSettingsUpdate.yaml
+++ b/components/schemas/whitelabelSettingsUpdate.yaml
@@ -9,6 +9,12 @@ properties:
   disableSupportMenu: 
     type: boolean
     description: Can be used to disable support menu
+  supportsThemes:
+    type: boolean
+  securityBanner:
+    type: string
+  externalLegalText:
+    type: string
   resetHeaderLogo: 
     type: boolean
     description: Resets header logo to default header logo

--- a/paths/api@whitelabel-settings@images.yaml
+++ b/paths/api@whitelabel-settings@images.yaml
@@ -10,34 +10,34 @@ post:
         schema: 
           type: object
           properties: 
-            headerLogo.file:
+            headerLogo:
               type: string
               format: binary
               description: Header logo image file, valid image types `png|jpg|svg`
             resetHeaderLogo:
               type: boolean
               description: Resets header logo to default
-            footerLogo.file:
+            footerLogo:
               type: string
               format: binary
               description: Footer logo image file, valid image types `png|jpg|svg`
             resetFooterLogo:
               type: boolean
               description: Resets footer logo to default
-            loginLogo.file:
+            loginLogo:
               type: string
               format: binary
               description: Login logo image file, valid image types `png|jpg|svg`
             resetLoginLogo:
               type: boolean
               description: Resets login logo to default
-            favicon.file:
+            favicon:
               type: string
               format: binary
               description: Favicon image file, valid image type ico
-            resetFaviconLogo:
+            resetFavicon:
               type: boolean
-              description: Resets favicon logo to default
+              description: Resets favicon to default
   responses:
     '200':
       description: Successful Response


### PR DESCRIPTION
Minimal contract fixes for `/api/whitelabel-settings` against gson + React Whitelabel settings UI.

## Changes
- Document response fields the UI reads: `account`, `supportsThemes`, `securityBanner`, `externalLegalText`
- Document the same fields on the update body
- Fix multipart image field names (`headerLogo` / `resetFavicon`, not `headerLogo.file` / `resetFaviconLogo`)
