### PR TITLE
Appliance-settings: Fix incorrect OpenAPI contract

### DIFF
--- a/components/examples/applianceSettings.json
+++ b/components/examples/applianceSettings.json
@@ -183,6 +183,10 @@
       "statsRetainmentPeriod": 30,
       "latestLinuxAgentVersion": "2.9.7",
       "latestWindowsAgentVersion": "6.0.0",
-      "vmeAppliance": false
+      "vmeAppliance": false,
+      "noProxy": null,
+      "maintenanceMode": false,
+      "dashboardsToDisplay": null,
+      "enableMurph": false
   }
 }

--- a/components/examples/applianceSettingsUpdate.json
+++ b/components/examples/applianceSettingsUpdate.json
@@ -39,6 +39,9 @@
     ],
     "defaultRoleId": 2,
     "defaultUserRoleId": 4,
-    "statsRetainmentPeriod": 30
+    "statsRetainmentPeriod": 30,
+    "noProxy": "localhost,127.0.0.1",
+    "dashboardsToDisplay": "home,cloud-list",
+    "enableMurph": false
   }
 }

--- a/components/schemas/applianceSettings.yaml
+++ b/components/schemas/applianceSettings.yaml
@@ -20,6 +20,89 @@ properties:
       - 'null'
   dockerPrivilegedMode:
     type: boolean
+  cloudSyncIntervalSeconds:
+    type:
+      - string
+      - 'null'
+  clusterSyncIntervalSeconds:
+    type:
+      - string
+      - 'null'
+  usageRetainmentPeriod:
+    type:
+      - string
+      - 'null'
+  invoiceRetainmentPeriod:
+    type:
+      - string
+      - 'null'
+  incidentRetainmentPeriod:
+    type:
+      - string
+      - 'null'
+  statsRetainmentPeriod:
+    type:
+      - string
+      - integer
+      - 'null'
+  reportsRetainmentPeriod:
+    type:
+      - string
+      - 'null'
+  httpBlacklistHosts:
+    type:
+      - string
+      - 'null'
+  httpApprovelistHosts:
+    type:
+      - string
+      - 'null'
+  exchangeUrl:
+    type:
+      - string
+      - 'null'
+  noAgent:
+    type: boolean
+  agentSSLVerify:
+    type: boolean
+  disableSSHPasswordAuth:
+    type: boolean
+  defaultLocale:
+    type:
+      - string
+      - 'null'
+  defaultVdiGateway:
+    type:
+      - string
+      - 'null'
+  maxOptionListSize:
+    type:
+      - string
+      - 'null'
+  passwordMinLength:
+    type:
+      - string
+      - 'null'
+  passwordMinUpperCase:
+    type:
+      - string
+      - 'null'
+  passwordMinNumbers:
+    type:
+      - string
+      - 'null'
+  passwordMinSymbols:
+    type:
+      - string
+      - 'null'
+  userBrowserSessionTimeout:
+    type:
+      - string
+      - 'null'
+  userBrowserSessionWarning:
+    type:
+      - string
+      - 'null'
   expirePwdDays:
     type:
       - string
@@ -64,6 +147,18 @@ properties:
     type:
       - string
       - 'null'
+  twilioAccountSid:
+    type:
+      - string
+      - 'null'
+  twilioSmsFrom:
+    type:
+      - string
+      - 'null'
+  twilioAuthToken:
+    type:
+      - string
+      - 'null'
   proxyHost:
     type:
       - string
@@ -92,6 +187,10 @@ properties:
     type:
       - string
       - 'null'
+  noProxy:
+    type:
+      - string
+      - 'null'
   currencyProvider:
     type:
       - string
@@ -100,6 +199,8 @@ properties:
     type:
       - string
       - 'null'
+  maintenanceMode:
+    type: boolean
   enabledZoneTypes:
     type:
       - array
@@ -112,13 +213,12 @@ properties:
           format: int64
         name:
           type: string
-  statsRetainmentPeriod:
-    type: integer
-    format: int64
   dashboardsToDisplay:
     type:
       - string
       - 'null'
+  enableMurph:
+    type: boolean
   vmeAppliance:
     type: boolean
   latestWindowsAgentVersion:

--- a/components/schemas/applianceSettingsUpdate.yaml
+++ b/components/schemas/applianceSettingsUpdate.yaml
@@ -109,6 +109,11 @@ properties:
       - string
       - 'null'
     description: Proxy workstation
+  noProxy:
+    type:
+      - string
+      - 'null'
+    description: Comma-delimited list of hosts that bypass the proxy
   currencyProvider:
     type: string
     description: Currency provider
@@ -201,3 +206,11 @@ properties:
   exchangeUrl:
     type: string
     description: "The url used for checking if there is an update for plugins. Default https\\://share.morpheusdata.com"
+  dashboardsToDisplay:
+    type:
+      - string
+      - 'null'
+    description: Comma-delimited dashboard IDs to display
+  enableMurph:
+    type: boolean
+    description: Enable Murph AI services

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -38,6 +38,8 @@ paths:
     $ref: paths/api@appliance-settings@maintenance.yaml
   /api/appliance-settings/reindex:
     $ref: paths/api@appliance-settings@reindex.yaml
+  /api/appliance-settings/zone-types:
+    $ref: paths/api@appliance-settings@zone-types.yaml
   /api/approval-items/{id}:
     $ref: paths/api@approval-items@id.yaml
   /api/approval-items/{id}/{action}:

--- a/paths/api@appliance-settings@maintenance.yaml
+++ b/paths/api@appliance-settings@maintenance.yaml
@@ -12,11 +12,18 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/200-success.yaml
+            type: object
+            properties:
+              success:
+                type: boolean
+              enabled:
+                type: boolean
+                description: Whether maintenance mode is enabled after the toggle
           examples:
             Successful Response:
               value:
-                $ref: ../components/examples/success.json
+                success: true
+                enabled: true
     '4XX':
       $ref: ../components/responses/4xx.yaml
     '5XX':

--- a/paths/api@appliance-settings@zone-types.yaml
+++ b/paths/api@appliance-settings@zone-types.yaml
@@ -1,0 +1,40 @@
+get:
+  summary: List Appliance Zone Types
+  description: List cloud types available to the appliance and whether each is enabled.
+  operationId: listApplianceSettingsZoneTypes
+  tags:
+    - Appliance Settings
+  responses:
+    '200':
+      description: Successful Response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              zoneTypes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                      format: int64
+                    name:
+                      type: string
+                    enabled:
+                      type: boolean
+          examples:
+            Successful Response:
+              value:
+                zoneTypes:
+                  - id: 22
+                    name: Alibaba Cloud
+                    enabled: true
+                  - id: 3
+                    name: Amazon
+                    enabled: false
+    '4XX':
+      $ref: ../components/responses/4xx.yaml
+    '5XX':
+      $ref: ../components/responses/5xx.yaml


### PR DESCRIPTION
Align appliance-settings OpenAPI with Grails public API + React UI (wrong-spec only).

### Fixes
- **GET `applianceSettings` schema** — document fields the UI already reads from gson (`passwordMin*`, session timeouts, retainment/sync intervals, Twilio, `exchangeUrl`, agent/SSH flags, `noProxy`, `maintenanceMode`, `enableMurph`, etc.). Example only adds the keys that were missing from the sample (no full rewrite).
- **PUT body** — add fields the form writes: `noProxy`, `dashboardsToDisplay`, `enableMurph`.
- **Missing path** — `GET /api/appliance-settings/zone-types` (appliance form cloud-type toggles).
- **Maintenance POST** — response is `{ success, enabled }` (UI reads `enabled`), not bare success only.
