### PR TITLE
Monitoring-settings: Fix incorrect OpenAPI contract

### DIFF
--- a/components/schemas/monitoringSettings.yaml
+++ b/components/schemas/monitoringSettings.yaml
@@ -4,26 +4,29 @@ properties:
     type: boolean
     description: Auto Create Checks
   availabilityTimeFrame:
-    type:
-      - integer
-      - 'null'
-    format: int32
     description: Availability Time Frame. The number of days availability should be calculated for. Changes will not take effect until your checks have passed their check interval.
     example: 30
+    oneOf:
+      - type: integer
+        format: int32
+      - type: string
+      - type: 'null'
   availabilityPrecision:
-    type:
-      - integer
-      - 'null'
-    format: int32
     description: Availability Precision. The number of decimal places availability should be displayed in. Can be anywhere between 0 and 5.
     example: 3
+    oneOf:
+      - type: integer
+        format: int32
+      - type: string
+      - type: 'null'
   defaultCheckInterval:
-    type:
-      - integer
-      - 'null'
-    format: int32
     description: Default Check Interval. The number of minutes to use as the default interval to use when creating new checks.
     example: 5
+    oneOf:
+      - type: integer
+        format: int32
+      - type: string
+      - type: 'null'
   serviceNow:
     type: object
     description: Service Now Settings
@@ -32,16 +35,20 @@ properties:
         type: boolean
         description: Enabled
       integration:
-        type: object
-        description: Service Now Integration Object
-        properties:
-          id:
-            type: integer
-            format: int64
-            description: Service Now Integration ID
-          name:
-            type: string
-            description: Service Now Integration Name
+        description: Service Now Integration (null when none selected). Write accepts `{ id }` only.
+        oneOf:
+          - type: 'null'
+          - type: object
+            properties:
+              id:
+                description: Service Now Integration ID
+                oneOf:
+                  - type: integer
+                    format: int64
+                  - type: string
+              name:
+                type: string
+                description: Service Now Integration Name
       newIncidentAction:
         type: string
         description: New Incident Action


### PR DESCRIPTION
Minimal monitoring-settings schema fixes against Grails gson + React UI.

## Changes
- Allow `serviceNow.integration` to be `null` (GET when none selected; PUT clears)
- Accept string or integer for availability/interval fields and integration `id` (UI writes strings; GET returns numbers)
