### PR TITLE
Backup-settings: Fix incorrect OpenAPI contract

### DIFF
--- a/components/examples/backupSettings.json
+++ b/components/examples/backupSettings.json
@@ -12,6 +12,8 @@
       "code": "dailyAtMidnight",
       "name": "Daily at Midnight"
     },
-    "retentionCount": 12
+    "retentionCount": 12,
+    "defaultSyntheticFullBackupsEnabled": false,
+    "defaultSyntheticFullBackupSchedule": null
   }
 }

--- a/components/schemas/backupSettings.yaml
+++ b/components/schemas/backupSettings.yaml
@@ -1,29 +1,55 @@
 type: object
-properties: 
-  backupsEnabled: 
+properties:
+  backupsEnabled:
     type: boolean
-  createBackups: 
+  createBackups:
     type: boolean
-  backupAppliance: 
+  backupAppliance:
     type: boolean
-  defaultStorageBucket: 
-    type: object
-    properties: 
-      id: 
-        type: integer
+  defaultStorageBucket:
+    description: Default backup storage bucket, or null when unset
+    oneOf:
+      - type: 'null'
+      - type: object
+        properties:
+          id:
+            type: integer
+            format: int64
+          name:
+            type: string
+  defaultSchedule:
+    description: Default backup schedule, or null when unset
+    oneOf:
+      - type: 'null'
+      - type: object
+        properties:
+          id:
+            type: integer
+            format: int64
+          code:
+            type: string
+          name:
+            type: string
+  retentionCount:
+    description: Maximum number of successful backups to retain
+    oneOf:
+      - type: integer
         format: int64
-      name: 
-        type: string
-  defaultSchedule: 
-    type: object
-    properties: 
-      id: 
-        type: integer
-        format: int64
-      code: 
-        type: string
-      name: 
-        type: string
-  retentionCount: 
-    type: integer
-    format: int64
+      - type: string
+      - type: 'null'
+  defaultSyntheticFullBackupsEnabled:
+    type: boolean
+    description: Whether synthetic full backups are enabled by default
+  defaultSyntheticFullBackupSchedule:
+    description: Default synthetic full backup schedule, or null when unset
+    oneOf:
+      - type: 'null'
+      - type: object
+        properties:
+          id:
+            type: integer
+            format: int64
+          code:
+            type: string
+          name:
+            type: string

--- a/components/schemas/backupSettings.yaml
+++ b/components/schemas/backupSettings.yaml
@@ -32,11 +32,10 @@ properties:
             type: string
   retentionCount:
     description: Maximum number of successful backups to retain
-    oneOf:
-      - type: integer
-        format: int64
-      - type: string
-      - type: 'null'
+    type:
+      - integer
+      - 'null'
+    format: int64
   defaultSyntheticFullBackupsEnabled:
     type: boolean
     description: Whether synthetic full backups are enabled by default

--- a/components/schemas/backupSettingsUpdate.yaml
+++ b/components/schemas/backupSettingsUpdate.yaml
@@ -3,10 +3,12 @@ properties:
   backupsEnabled: 
     type: boolean
     description: Use this to enable / disable scheduled backups
-  retentionCount: 
-    type: integer
-    format: int64
+  retentionCount:
     description: Maximum number of successful backups to retain
+    oneOf:
+      - type: integer
+        format: int64
+      - type: string
   createBackups: 
     type: boolean
     description: Use this to enable / disable create backups

--- a/components/schemas/backupSettingsUpdate.yaml
+++ b/components/schemas/backupSettingsUpdate.yaml
@@ -5,10 +5,10 @@ properties:
     description: Use this to enable / disable scheduled backups
   retentionCount:
     description: Maximum number of successful backups to retain
-    oneOf:
-      - type: integer
-        format: int64
-      - type: string
+    type:
+      - integer
+      - 'null'
+    format: int64
   createBackups: 
     type: boolean
     description: Use this to enable / disable create backups


### PR DESCRIPTION
Minimal backup-settings contract fixes against public API gson + controller.

## Changes
- Document GET synthetic full fields (`defaultSyntheticFullBackupsEnabled`, `defaultSyntheticFullBackupSchedule`)
- Allow null for nested schedule/bucket objects when unset
- Allow string|integer `retentionCount` on write (and flexible GET)
