### PR TITLE
Align provisioning-licenses OpenAPI with Settings UI public API calls

### DIFF
--- a/components/examples/provisioningLicenseTypes.json
+++ b/components/examples/provisioningLicenseTypes.json
@@ -1,0 +1,18 @@
+{
+  "licenseTypes": [
+    {
+      "id": 1,
+      "name": "Windows",
+      "code": "win",
+      "description": "Windows OS license key",
+      "visibility": "public",
+      "account": null
+    }
+  ],
+  "meta": {
+    "size": 1,
+    "total": 1,
+    "offset": 0,
+    "max": 25
+  }
+}

--- a/components/examples/provisioningLicensesCreate.json
+++ b/components/examples/provisioningLicensesCreate.json
@@ -1,7 +1,9 @@
 {
   "license": {
     "name": "Test Windows",
-    "licenseType": "win",
+    "licenseType": {
+      "code": "win"
+    },
     "licenseKey": "12345-678-ABCDEFG-HIJKL",
     "orgName": "Acme Motors",
     "fullName": "Bugs Bunny",
@@ -9,9 +11,18 @@
     "copies": 5,
     "description": "A windows key for testing",
     "virtualImages": [
-      1,
-      2,
-      3
+      {
+        "id": 1
+      },
+      {
+        "id": 2
+      },
+      {
+        "id": 3
+      }
     ]
+  },
+  "tenantPermissions": {
+    "accounts": "1,3"
   }
 }

--- a/components/examples/provisioningLicensesCreateSuccess.json
+++ b/components/examples/provisioningLicensesCreateSuccess.json
@@ -1,6 +1,30 @@
 {
   "success": true,
   "license": {
-    "id": 1
+    "id": 2,
+    "name": "2012 R2 Standard",
+    "description": "2012 R2 Standard",
+    "licenseType": {
+      "id": 1,
+      "code": "win",
+      "name": "Windows"
+    },
+    "licenseKey": "*************************AB3E",
+    "orgName": "Acme Motors",
+    "fullName": "Bugs Bunny",
+    "licenseVersion": "2012 R2 Standard",
+    "copies": 1,
+    "reservationCount": 0,
+    "tenants": [],
+    "virtualImages": [
+      {
+        "id": 2021,
+        "name": "Windows-Server-R2-AL"
+      }
+    ],
+    "account": {
+      "id": 1,
+      "name": "Acme"
+    }
   }
 }

--- a/components/examples/provisioningLicensesUpdate.json
+++ b/components/examples/provisioningLicensesUpdate.json
@@ -1,6 +1,14 @@
 {
   "license": {
     "name": "QA Windows Key",
-    "copies": 5
+    "copies": 5,
+    "virtualImages": [
+      {
+        "id": 1
+      }
+    ]
+  },
+  "tenantPermissions": {
+    "accounts": "1,3"
   }
 }

--- a/components/schemas/provisioningLicenseType.yaml
+++ b/components/schemas/provisioningLicenseType.yaml
@@ -1,0 +1,30 @@
+type: object
+description: License type from ProvisioningLicenseTypesController (`_licenseType.gson`).
+properties:
+  id:
+    type: integer
+    format: int64
+  name:
+    type: string
+  code:
+    type: string
+  description:
+    type:
+      - string
+      - 'null'
+  visibility:
+    description: Domain visibility value
+    oneOf:
+      - type: string
+      - type: boolean
+      - type: 'null'
+  account:
+    type:
+      - object
+      - 'null'
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string

--- a/components/schemas/provisioningLicenseType.yaml
+++ b/components/schemas/provisioningLicenseType.yaml
@@ -1,5 +1,5 @@
 type: object
-description: License type from ProvisioningLicenseTypesController (`_licenseType.gson`).
+description: Provisioning license type.
 properties:
   id:
     type: integer

--- a/components/schemas/provisioningLicensesCreate.yaml
+++ b/components/schemas/provisioningLicensesCreate.yaml
@@ -9,7 +9,7 @@ properties:
     description: Name
   licenseType:
     description: |
-      License type code string, or object with `code` and/or `id` (UI sends `{ "code": "win" }`).
+      License type code string, or object with `code` and/or `id`.
     oneOf:
       - type: string
         example: win
@@ -44,7 +44,7 @@ properties:
   virtualImages:
     type: array
     description: |
-      Virtual image ids, or objects with `id` (UI sends `[{ "id": 1 }]`).
+      Virtual image ids, or objects with `id`.
     items:
       oneOf:
         - type: integer

--- a/components/schemas/provisioningLicensesCreate.yaml
+++ b/components/schemas/provisioningLicensesCreate.yaml
@@ -7,10 +7,20 @@ properties:
   name: 
     type: string
     description: Name
-  licenseType: 
-    type: string
-    description: License Type - The license type code.
-    example: win
+  licenseType:
+    description: |
+      License type code string, or object with `code` and/or `id` (UI sends `{ "code": "win" }`).
+    oneOf:
+      - type: string
+        example: win
+      - type: object
+        properties:
+          id:
+            type: integer
+            format: int64
+          code:
+            type: string
+            example: win
   licenseKey: 
     type: string
     description: License Key - The license key, to be kept a secret.
@@ -31,12 +41,19 @@ properties:
   description: 
     type: string
     description: Description
-  virtualImages: 
+  virtualImages:
     type: array
-    description: Virtual Images - Array of Virtual Image IDs to associate with license.
-    items: 
-      type: integer
-      format: int64
+    description: |
+      Virtual image ids, or objects with `id` (UI sends `[{ "id": 1 }]`).
+    items:
+      oneOf:
+        - type: integer
+          format: int64
+        - type: object
+          properties:
+            id:
+              type: integer
+              format: int64
   tenants: 
     type: array
     description: Tenants - Array of tenants that are allowed to use the key.

--- a/components/schemas/provisioningLicensesUpdate.yaml
+++ b/components/schemas/provisioningLicensesUpdate.yaml
@@ -14,12 +14,19 @@ properties:
   description: 
     type: string
     description: Description
-  virtualImages: 
+  virtualImages:
     type: array
-    description: Virtual Images - Array of Virtual Image IDs to associate with license.
-    items: 
-      type: integer
-      format: int64
+    description: |
+      Virtual image ids, or objects with `id` (UI sends `[{ "id": 1 }]`). Replaces set when provided.
+    items:
+      oneOf:
+        - type: integer
+          format: int64
+        - type: object
+          properties:
+            id:
+              type: integer
+              format: int64
   tenants: 
     type: array
     description: Tenants - Array of tenants that are allowed to use the key.

--- a/components/schemas/provisioningLicensesUpdate.yaml
+++ b/components/schemas/provisioningLicensesUpdate.yaml
@@ -17,7 +17,7 @@ properties:
   virtualImages:
     type: array
     description: |
-      Virtual image ids, or objects with `id` (UI sends `[{ "id": 1 }]`). Replaces set when provided.
+      Virtual image ids, or objects with `id`. Replaces set when provided.
     items:
       oneOf:
         - type: integer

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -983,6 +983,8 @@ paths:
     $ref: paths/api@provision-types.yaml
   /api/provision-types/{id}:
     $ref: paths/api@provision-types@id.yaml
+  /api/provisioning-license-types:
+    $ref: paths/api@provisioning-license-types.yaml
   /api/provisioning-licenses:
     $ref: paths/api@provisioning-licenses.yaml
   /api/provisioning-licenses/{id}:

--- a/paths/api@provisioning-license-types.yaml
+++ b/paths/api@provisioning-license-types.yaml
@@ -1,8 +1,7 @@
 get:
   summary: List provisioning license types
   description: |
-    License types for the Settings → Software Licenses editor type selector.
-    UI calls `GET /api/provisioning-license-types` only (no show).
+    Lists available provisioning license types.
   operationId: listProvisioningLicenseTypes
   tags:
     - Provisioning Licenses

--- a/paths/api@provisioning-license-types.yaml
+++ b/paths/api@provisioning-license-types.yaml
@@ -1,0 +1,36 @@
+get:
+  summary: List provisioning license types
+  description: |
+    License types for the Settings → Software Licenses editor type selector.
+    UI calls `GET /api/provisioning-license-types` only (no show).
+  operationId: listProvisioningLicenseTypes
+  tags:
+    - Provisioning Licenses
+  parameters:
+    - $ref: ../components/parameters/max.yaml
+    - $ref: ../components/parameters/offset.yaml
+    - $ref: ../components/parameters/phrase.yaml
+    - $ref: ../components/parameters/name.yaml
+    - $ref: ../components/parameters/code.yaml
+  responses:
+    '200':
+      description: Successful Request
+      content:
+        application/json:
+          schema:
+            allOf:
+              - type: object
+                properties:
+                  licenseTypes:
+                    type: array
+                    items:
+                      $ref: ../components/schemas/provisioningLicenseType.yaml
+              - $ref: ../components/schemas/meta.yaml
+          examples:
+            License Types Response:
+              value:
+                $ref: ../components/examples/provisioningLicenseTypes.json
+    '4XX':
+      $ref: ../components/responses/4xx.yaml
+    '5XX':
+      $ref: ../components/responses/5xx.yaml

--- a/paths/api@provisioning-licenses.yaml
+++ b/paths/api@provisioning-licenses.yaml
@@ -58,7 +58,7 @@ post:
             tenantPermissions:
               type: object
               description: |
-                Tenant access. UI sends `accounts` as a comma-separated string of account ids.
+                Tenant access. `accounts` is a comma-separated string of account ids.
               properties:
                 accounts:
                   type: string
@@ -70,7 +70,7 @@ post:
               $ref: ../components/examples/provisioningLicensesCreate.json
   responses:
     '200':
-      description: Successful Response (show template — full license object)
+      description: Successful Response
       content:
         application/json:
           schema:

--- a/paths/api@provisioning-licenses.yaml
+++ b/paths/api@provisioning-licenses.yaml
@@ -45,20 +45,32 @@ post:
   tags:
     - Provisioning Licenses
   requestBody:
+    required: true
     content:
       application/json:
         schema:
           type: object
+          required:
+            - license
           properties:
             license:
               $ref: ../components/schemas/provisioningLicensesCreate.yaml
+            tenantPermissions:
+              type: object
+              description: |
+                Tenant access. UI sends `accounts` as a comma-separated string of account ids.
+              properties:
+                accounts:
+                  type: string
+                  description: Comma-separated tenant account ids
+                  example: "1,3"
         examples:
           License Create Request:
             value:
               $ref: ../components/examples/provisioningLicensesCreate.json
   responses:
     '200':
-      description: Successful Response
+      description: Successful Response (show template — full license object)
       content:
         application/json:
           schema:
@@ -67,11 +79,7 @@ post:
               - type: object
                 properties:
                   license:
-                    type: object
-                    properties: 
-                      id:
-                        type: integer
-                        format: int64
+                    $ref: ../components/schemas/provisioningLicense.yaml
           examples:
             Successful Response:
               value:

--- a/paths/api@provisioning-licenses@id.yaml
+++ b/paths/api@provisioning-licenses@id.yaml
@@ -47,7 +47,7 @@ put:
             tenantPermissions:
               type: object
               description: |
-                Tenant access. UI sends `accounts` as a comma-separated string of account ids.
+                Tenant access. `accounts` is a comma-separated string of account ids.
               properties:
                 accounts:
                   type: string
@@ -59,7 +59,7 @@ put:
               $ref: ../components/examples/provisioningLicensesUpdate.json
   responses:
     '200':
-      description: Successful Response (show template — full license object)
+      description: Successful Response
       content:
         application/json:
           schema:

--- a/paths/api@provisioning-licenses@id.yaml
+++ b/paths/api@provisioning-licenses@id.yaml
@@ -34,20 +34,32 @@ put:
   parameters:
     - $ref: ../components/parameters/id-path.yaml
   requestBody:
+    required: true
     content:
       application/json:
         schema:
           type: object
+          required:
+            - license
           properties:
             license:
               $ref: ../components/schemas/provisioningLicensesUpdate.yaml
+            tenantPermissions:
+              type: object
+              description: |
+                Tenant access. UI sends `accounts` as a comma-separated string of account ids.
+              properties:
+                accounts:
+                  type: string
+                  description: Comma-separated tenant account ids
+                  example: "1,3"
         examples:
           License Update Request:
             value:
               $ref: ../components/examples/provisioningLicensesUpdate.json
   responses:
     '200':
-      description: Successful Response
+      description: Successful Response (show template — full license object)
       content:
         application/json:
           schema:
@@ -56,11 +68,7 @@ put:
               - type: object
                 properties:
                   license:
-                    type: object
-                    properties: 
-                      id:
-                        type: integer
-                        format: int64
+                    $ref: ../components/schemas/provisioningLicense.yaml
           examples:
             Successful Response:
               value:


### PR DESCRIPTION
- Create/update body: root `tenantPermissions.accounts` (comma-separated); `licenseType` object or string; `virtualImages` as `[{id}]` or ids
- Create/update 200: full `license` (show template), not id-only
- Document missing `GET /api/provisioning-license-types`
