### PR TITLE
Fix incorrect license OpenAPI contract

### DIFF
--- a/components/examples/license.json
+++ b/components/examples/license.json
@@ -198,6 +198,21 @@
     "xaas": 5,
     "executions": 43,
     "distributedWorkers": 0,
-    "discoveredObjects": 0
-  }
+    "discoveredObjects": 0,
+    "sockets": 0,
+    "hypervisorSocketCount": 0,
+    "publicVirtualMachineCount": 0,
+    "publicVirtualMachineSocketCount": 0
+  },
+  "licenseLimits": [
+    {
+      "code": "maxManagedServers",
+      "max": 15,
+      "used": 14,
+      "percentUsed": 0.9333333333333333,
+      "warning": true,
+      "limitReached": false
+    }
+  ],
+  "limitReached": false
 }

--- a/components/schemas/license.yaml
+++ b/components/schemas/license.yaml
@@ -27,6 +27,10 @@ properties:
         type: integer
         format: int64
         description: Total Workloads
+      managedServers:
+        type: integer
+        format: int64
+        description: Total Managed Servers
       discoveredServers:
         type: integer
         format: int64
@@ -43,6 +47,22 @@ properties:
         type: integer
         format: int64
         description: Total HPE VM Sockets
+      sockets:
+        type: integer
+        format: int64
+        description: Total Sockets
+      hypervisorSocketCount:
+        type: integer
+        format: int64
+        description: Hypervisor Socket Count
+      publicVirtualMachineCount:
+        type: integer
+        format: int64
+        description: Public Virtual Machine Count
+      publicVirtualMachineSocketCount:
+        type: integer
+        format: int64
+        description: Public Virtual Machine Socket Count
       iac:
         type: integer
         format: int64
@@ -63,3 +83,31 @@ properties:
         type: integer
         format: int64
         description: Total Discovered Objects
+  licenseLimits:
+    type: array
+    description: Per-metric limits with current usage
+    items:
+      type: object
+      properties:
+        code:
+          type: string
+        max:
+          type:
+            - integer
+            - number
+            - 'null'
+        used:
+          type:
+            - integer
+            - number
+        percentUsed:
+          type: number
+        warning:
+          type: boolean
+        limitReached:
+          type: boolean
+        unit:
+          type: string
+  limitReached:
+    type: boolean
+    description: True when any license limit has been reached

--- a/paths/api@license.yaml
+++ b/paths/api@license.yaml
@@ -84,8 +84,7 @@ delete:
       in: query
       description: Key ID (only the first 8 characters are required to identify license to uninstall).
       schema:
-        type: integer
-        format: int64
+        type: string
   responses:
     '200':
       description: License uninstalled successfully.


### PR DESCRIPTION
Wrong-spec alignment for Settings → License public API (`GET/POST/DELETE /api/license`).

## Changes
- Document `licenseLimits` and `limitReached` returned by `getLicenseInfoWithUsage`
- Add missing `currentUsage` fields the UI maps (managedServers, sockets, hypervisor/public VM counts)
- Type DELETE `keyId` as string (prefix id), not integer
