### PR TITLE
Align roles OpenAPI with React admin public API usage

### DIFF
--- a/components/schemas/rolePermissionAccessLevelsForResource.yaml
+++ b/components/schemas/rolePermissionAccessLevelsForResource.yaml
@@ -1,3 +1,4 @@
 - default
+- ""
 - full
 - none

--- a/components/schemas/rolePermissionAccessLevelsForResource.yaml
+++ b/components/schemas/rolePermissionAccessLevelsForResource.yaml
@@ -1,4 +1,3 @@
 - default
-- ""
 - full
 - none

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1022,7 +1022,7 @@ paths:
   /api/roles/{id}/update-blueprint:
     $ref: paths/api@roles@id@update-blueprint.yaml
   /api/roles/{id}/update-app-template:
-    $ref: paths/api@roles@id@update-blueprint.yaml
+    $ref: paths/api@roles@id@update-app-template.yaml
   /api/roles/{id}/update-catalog-item-type:
     $ref: paths/api@roles@id@update-catalog-item-type.yaml
   /api/roles/{id}/update-cloud:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1021,6 +1021,8 @@ paths:
     $ref: paths/api@roles@id.yaml
   /api/roles/{id}/update-blueprint:
     $ref: paths/api@roles@id@update-blueprint.yaml
+  /api/roles/{id}/update-app-template:
+    $ref: paths/api@roles@id@update-blueprint.yaml
   /api/roles/{id}/update-catalog-item-type:
     $ref: paths/api@roles@id@update-catalog-item-type.yaml
   /api/roles/{id}/update-cloud:

--- a/paths/api@roles.yaml
+++ b/paths/api@roles.yaml
@@ -101,6 +101,12 @@ post:
           required:
             - role
           properties:
+            baseRoleId:
+              type: integer
+              format: int64
+              description: >
+                Copy permissions from this base role. Accepted at the request root (as the React UI sends)
+                or under `role.baseRoleId`. If omitted, the role is created without copied permissions.
             role:
               type: object
               description: Payload for creating a new role
@@ -133,15 +139,31 @@ post:
                 baseRoleId:
                   type: integer
                   format: int64
-                  description: Base Role ID. Create the new role with the same permissions and access levels that the specified base role has. If this is not passed, the role is create without any permissions.
+                  description: >
+                    Base Role ID under `role` (also accepted at request root). Create the new role with the same
+                    permissions and access levels as the specified base role. If omitted, the role is created
+                    without copied permissions.
                 multitenant:
-                  type: boolean
+                  description: >
+                    Multitenant roles are copied to all tenant accounts and kept in sync until a
+                    sub-tenant user modifies their copy of the role. *Only available to master tenant,
+                    only applies to user roles*. Accepts boolean or the strings `on`/`off`/`true`/`false`
+                    (UI sends `on`/`off`).
+                  oneOf:
+                    - type: boolean
+                    - type: string
+                      enum: [on, off, 'true', 'false']
                   default: false
-                  description: Multitenant roles are copied to all tenant accounts and kept in sync until a sub-tenant user modifies their copy of the role. *Only available to master tenant, only applies to user roles*
                 multitenantLocked:
-                  type: boolean
+                  description: >
+                    Multitenant Locked, prevents sub-tenant users from modifying their copy of multitenant
+                    roles. *Only available to master tenant, only applies to user roles*. Accepts boolean
+                    or the strings `on`/`off`/`true`/`false` (UI sends `on`/`off`).
+                  oneOf:
+                    - type: boolean
+                    - type: string
+                      enum: [on, off, 'true', 'false']
                   default: false
-                  description: Multitenant Locked, prevents sub-tenant users from modifying their copy of multitenant roles. *Only available to master tenant, only applies to user roles*
                 defaultPersona:
                   description: >
                     Default persona. Accepts persona code string, persona id, or object
@@ -461,11 +483,17 @@ post:
                 owner:
                   type: integer
                   format: int64
-                  description: Set the role owner (tenant) by ID. *Only available to master tenant*. Alias of `tenant`.
+                  description: >
+                    Set the role owner (tenant) by ID. *Only available to master tenant*.
+                    Aliases: `tenant`, `tenantId` (UI tenants flow sends `tenantId`).
                 tenant:
                   type: integer
                   format: int64
                   description: Alias for `owner`
+                tenantId:
+                  type: integer
+                  format: int64
+                  description: Alias for `owner` / `tenant` (accepted via `tenantId` field binding)
   responses:
     '200':
       description: Role Object

--- a/paths/api@roles.yaml
+++ b/paths/api@roles.yaml
@@ -105,7 +105,7 @@ post:
               type: integer
               format: int64
               description: >
-                Copy permissions from this base role. Accepted at the request root (as the React UI sends)
+                Copy permissions from this base role. Accepted at the request root
                 or under `role.baseRoleId`. If omitted, the role is created without copied permissions.
             role:
               type: object
@@ -147,8 +147,7 @@ post:
                   description: >
                     Multitenant roles are copied to all tenant accounts and kept in sync until a
                     sub-tenant user modifies their copy of the role. *Only available to master tenant,
-                    only applies to user roles*. Accepts boolean or the strings `on`/`off`/`true`/`false`
-                    (UI sends `on`/`off`).
+                    only applies to user roles*. Accepts boolean or the strings `on`/`off`/`true`/`false`.
                   oneOf:
                     - type: boolean
                     - type: string
@@ -158,7 +157,7 @@ post:
                   description: >
                     Multitenant Locked, prevents sub-tenant users from modifying their copy of multitenant
                     roles. *Only available to master tenant, only applies to user roles*. Accepts boolean
-                    or the strings `on`/`off`/`true`/`false` (UI sends `on`/`off`).
+                    or the strings `on`/`off`/`true`/`false`.
                   oneOf:
                     - type: boolean
                     - type: string
@@ -485,7 +484,7 @@ post:
                   format: int64
                   description: >
                     Set the role owner (tenant) by ID. *Only available to master tenant*.
-                    Aliases: `tenant`, `tenantId` (UI tenants flow sends `tenantId`).
+                    Aliases: `tenant`, `tenantId`.
                 tenant:
                   type: integer
                   format: int64

--- a/paths/api@roles.yaml
+++ b/paths/api@roles.yaml
@@ -101,12 +101,6 @@ post:
           required:
             - role
           properties:
-            baseRoleId:
-              type: integer
-              format: int64
-              description: >
-                Copy permissions from this base role. Accepted at the request root
-                or under `role.baseRoleId`. If omitted, the role is created without copied permissions.
             role:
               type: object
               description: Payload for creating a new role
@@ -140,29 +134,21 @@ post:
                   type: integer
                   format: int64
                   description: >
-                    Base Role ID under `role` (also accepted at request root). Create the new role with the same
-                    permissions and access levels as the specified base role. If omitted, the role is created
-                    without copied permissions.
+                    Base Role ID. Create the new role with the same permissions and access levels as the
+                    specified base role. If omitted, the role is created without copied permissions.
                 multitenant:
+                  type: boolean
+                  default: false
                   description: >
                     Multitenant roles are copied to all tenant accounts and kept in sync until a
                     sub-tenant user modifies their copy of the role. *Only available to master tenant,
-                    only applies to user roles*. Accepts boolean or the strings `on`/`off`/`true`/`false`.
-                  oneOf:
-                    - type: boolean
-                    - type: string
-                      enum: [on, off, 'true', 'false']
-                  default: false
+                    only applies to user roles*.
                 multitenantLocked:
+                  type: boolean
+                  default: false
                   description: >
                     Multitenant Locked, prevents sub-tenant users from modifying their copy of multitenant
-                    roles. *Only available to master tenant, only applies to user roles*. Accepts boolean
-                    or the strings `on`/`off`/`true`/`false`.
-                  oneOf:
-                    - type: boolean
-                    - type: string
-                      enum: [on, off, 'true', 'false']
-                  default: false
+                    roles. *Only available to master tenant, only applies to user roles*.
                 defaultPersona:
                   description: >
                     Default persona. Accepts persona code string, persona id, or object

--- a/paths/api@roles@id.yaml
+++ b/paths/api@roles@id.yaml
@@ -81,8 +81,7 @@ put:
                   description: >
                     Multitenant roles are copied to all tenant accounts and kept in sync until a
                     sub-tenant user modifies their copy of the role. *Only available to master tenant,
-                    only applies to user roles*. Accepts boolean or the strings `on`/`off`/`true`/`false`
-                    (UI sends `on`/`off`).
+                    only applies to user roles*. Accepts boolean or the strings `on`/`off`/`true`/`false`.
                   oneOf:
                     - type: boolean
                     - type: string
@@ -91,7 +90,7 @@ put:
                   description: >
                     Multitenant Locked, prevents sub-tenant users from modifying their copy of multitenant
                     roles. *Only available to master tenant, only applies to user roles*. Accepts boolean
-                    or the strings `on`/`off`/`true`/`false` (UI sends `on`/`off`).
+                    or the strings `on`/`off`/`true`/`false`.
                   oneOf:
                     - type: boolean
                     - type: string

--- a/paths/api@roles@id.yaml
+++ b/paths/api@roles@id.yaml
@@ -78,11 +78,24 @@ put:
                     - 'null'
                   description: An optional override for the default landing page after login for a user.
                 multitenant:
-                  type: boolean
-                  description: Multitenant roles are copied to all tenant accounts and kept in sync until a sub-tenant user modifies their copy of the role. *Only available to master tenant, only applies to user roles*
+                  description: >
+                    Multitenant roles are copied to all tenant accounts and kept in sync until a
+                    sub-tenant user modifies their copy of the role. *Only available to master tenant,
+                    only applies to user roles*. Accepts boolean or the strings `on`/`off`/`true`/`false`
+                    (UI sends `on`/`off`).
+                  oneOf:
+                    - type: boolean
+                    - type: string
+                      enum: [on, off, 'true', 'false']
                 multitenantLocked:
-                  type: boolean
-                  description: Multitenant Locked, prevents sub-tenant users from modifying their copy of multitenant roles. *Only available to master tenant, only applies to user roles*
+                  description: >
+                    Multitenant Locked, prevents sub-tenant users from modifying their copy of multitenant
+                    roles. *Only available to master tenant, only applies to user roles*. Accepts boolean
+                    or the strings `on`/`off`/`true`/`false` (UI sends `on`/`off`).
+                  oneOf:
+                    - type: boolean
+                    - type: string
+                      enum: [on, off, 'true', 'false']
                 defaultPersona:
                   description: >
                     Default persona. Accepts persona code string, persona id, or object

--- a/paths/api@roles@id.yaml
+++ b/paths/api@roles@id.yaml
@@ -78,23 +78,16 @@ put:
                     - 'null'
                   description: An optional override for the default landing page after login for a user.
                 multitenant:
+                  type: boolean
                   description: >
                     Multitenant roles are copied to all tenant accounts and kept in sync until a
                     sub-tenant user modifies their copy of the role. *Only available to master tenant,
-                    only applies to user roles*. Accepts boolean or the strings `on`/`off`/`true`/`false`.
-                  oneOf:
-                    - type: boolean
-                    - type: string
-                      enum: [on, off, 'true', 'false']
+                    only applies to user roles*.
                 multitenantLocked:
+                  type: boolean
                   description: >
                     Multitenant Locked, prevents sub-tenant users from modifying their copy of multitenant
-                    roles. *Only available to master tenant, only applies to user roles*. Accepts boolean
-                    or the strings `on`/`off`/`true`/`false`.
-                  oneOf:
-                    - type: boolean
-                    - type: string
-                      enum: [on, off, 'true', 'false']
+                    roles. *Only available to master tenant, only applies to user roles*.
                 defaultPersona:
                   description: >
                     Default persona. Accepts persona code string, persona id, or object

--- a/paths/api@roles@id@update-app-template.yaml
+++ b/paths/api@roles@id@update-app-template.yaml
@@ -1,13 +1,12 @@
 put:
-  summary: Customizing Blueprint Access
+  summary: Customizing App Template Access
   description: >
-    Customizing Blueprint (App Template) Access.
-
-    Equivalent alias: `PUT /api/roles/{id}/update-app-template`.
+    Alias of `PUT /api/roles/{id}/update-blueprint`. Same request body and behavior
+    (blueprint / app template resource grants).
 
     Body accepts `appTemplateId`, `blueprintId` / `bluePrintId`, or `allAppTemplates` /
     `allBlueprints` with `access`. Use `access: default` to clear the grant.
-  operationId: updateRoleBlueprintAccess
+  operationId: updateRoleAppTemplateAccess
   parameters:
     - $ref: ../components/parameters/id-path.yaml
   tags:

--- a/paths/api@roles@id@update-blueprint.yaml
+++ b/paths/api@roles@id@update-blueprint.yaml
@@ -5,10 +5,10 @@ put:
 
     Public routes (both map to the same action):
     - `PUT /api/roles/{id}/update-blueprint`
-    - `PUT /api/roles/{id}/update-app-template` (path used by the React admin UI)
+    - `PUT /api/roles/{id}/update-app-template`
 
-    Body accepts `appTemplateId` (UI), `blueprintId` / `bluePrintId`, or `allAppTemplates` /
-    `allBlueprints` with `access`. Empty-string `access` clears the grant (UI sends `""` for default).
+    Body accepts `appTemplateId`, `blueprintId` / `bluePrintId`, or `allAppTemplates` /
+    `allBlueprints` with `access`. Empty-string `access` clears the grant (default).
   operationId: updateRoleBlueprintAccess
   parameters:
     - $ref: ../components/parameters/id-path.yaml

--- a/paths/api@roles@id@update-blueprint.yaml
+++ b/paths/api@roles@id@update-blueprint.yaml
@@ -8,7 +8,7 @@ put:
     - `PUT /api/roles/{id}/update-app-template`
 
     Body accepts `appTemplateId`, `blueprintId` / `bluePrintId`, or `allAppTemplates` /
-    `allBlueprints` with `access`. Empty-string `access` clears the grant (default).
+    `allBlueprints` with `access`. Use `access: default` to clear the grant.
   operationId: updateRoleBlueprintAccess
   parameters:
     - $ref: ../components/parameters/id-path.yaml

--- a/paths/api@roles@id@update-blueprint.yaml
+++ b/paths/api@roles@id@update-blueprint.yaml
@@ -1,10 +1,14 @@
 put:
   summary: Customizing Blueprint Access
   description: >
-    Customizing Blueprint Access.
+    Customizing Blueprint (App Template) Access.
 
-    The API also accepts `PUT /api/roles/{id}/update-app-template` as an equivalent
-    alias for this endpoint.
+    Public routes (both map to the same action):
+    - `PUT /api/roles/{id}/update-blueprint`
+    - `PUT /api/roles/{id}/update-app-template` (path used by the React admin UI)
+
+    Body accepts `appTemplateId` (UI), `blueprintId` / `bluePrintId`, or `allAppTemplates` /
+    `allBlueprints` with `access`. Empty-string `access` clears the grant (UI sends `""` for default).
   operationId: updateRoleBlueprintAccess
   parameters:
     - $ref: ../components/parameters/id-path.yaml


### PR DESCRIPTION
## Changes
- Register `PUT /api/roles/{id}/update-app-template` (UI path; same as `update-blueprint`)
- Document root `baseRoleId` on create (UI payload shape)
- Document `tenantId` as owner alias on create
- Allow multitenant flags as boolean or `on`/`off` strings
- Allow empty-string `access` on resource permission updates
