### PR TITLE
Align prices OpenAPI with Plans UI public API

### DIFF
--- a/components/parameters/priceType.yaml
+++ b/components/parameters/priceType.yaml
@@ -6,7 +6,6 @@ description: |
   * `compute` - Memory + CPU
   * `memory` - Memory
   * `cores` - Cores
-  * `cpu` - CPU
   * `storage` - Storage
   * `datastore` - Datastore
   * `platform` - Platform
@@ -21,7 +20,6 @@ schema:
     - compute
     - memory
     - cores
-    - cpu
     - storage
     - datastore
     - platform

--- a/components/parameters/priceType.yaml
+++ b/components/parameters/priceType.yaml
@@ -6,10 +6,14 @@ description: |
   * `compute` - Memory + CPU
   * `memory` - Memory
   * `cores` - Cores
+  * `cpu` - CPU
   * `storage` - Storage
   * `datastore` - Datastore
   * `platform` - Platform
-  * `software` - Software
+  * `software` - Software (response alias for software_or_service)
+  * `software_or_service` - Software or service
+  * `load_balancer` - Load Balancer
+  * `load_balancer_virtual_server` - Load Balancer Virtual Server
 schema:
   type: string
   enum:
@@ -17,7 +21,11 @@ schema:
     - compute
     - memory
     - cores
+    - cpu
     - storage
     - datastore
     - platform
     - software
+    - software_or_service
+    - load_balancer
+    - load_balancer_virtual_server

--- a/components/schemas/price.yaml
+++ b/components/schemas/price.yaml
@@ -81,5 +81,11 @@ properties:
       - 'null'
   account:
     type:
-      - string
+      - object
       - 'null'
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -974,6 +974,8 @@ paths:
     $ref: paths/api@price-sets@id@deactivate.yaml
   /api/prices:
     $ref: paths/api@prices.yaml
+  /api/prices/currencies:
+    $ref: paths/api@prices@currencies.yaml
   /api/prices/{id}:
     $ref: paths/api@prices@id.yaml
   /api/prices/{id}/deactivate:

--- a/paths/api@prices.yaml
+++ b/paths/api@prices.yaml
@@ -97,7 +97,6 @@ post:
                     * `platform` - Platform
                     * `software` - Software (accepted alias; stored as software_or_service)
                     * `software_or_service` - Software or service
-                    * `cpu` - CPU
                     * `load_balancer` - Load Balancer
                     * `load_balancer_virtual_server` - Load Balancer Virtual Server
                   enum:
@@ -105,7 +104,6 @@ post:
                     - compute
                     - memory
                     - cores
-                    - cpu
                     - storage
                     - datastore
                     - platform

--- a/paths/api@prices.yaml
+++ b/paths/api@prices.yaml
@@ -173,7 +173,7 @@ post:
                 softwareOrService:
                   type: string
                   description: |
-                    Software or service name. Preferred request field used by the UI.
+                    Software or service name.
                     Required when price type is software / software_or_service.
                 volumeType:
                   type: object

--- a/paths/api@prices.yaml
+++ b/paths/api@prices.yaml
@@ -10,15 +10,17 @@ get:
     - $ref: ../components/parameters/offset.yaml
     - $ref: ../components/parameters/sort.yaml
     - $ref: ../components/parameters/direction.yaml
+    - $ref: ../components/parameters/order.yaml
     - $ref: ../components/parameters/phrase.yaml
     - $ref: ../components/parameters/name.yaml
+    - $ref: ../components/parameters/code.yaml
     - $ref: ../components/parameters/includeInactive.yaml
     - $ref: ../components/parameters/priceType.yaml
     - $ref: ../components/parameters/platform.yaml
     - $ref: ../components/parameters/currency.yaml
-    - name: type
+    - name: priceUnit
       in: query
-      description: Filter by type code
+      description: Filter by price unit (repeatable)
       schema:
         type: string
   responses:
@@ -93,7 +95,9 @@ post:
                     * `storage` - Storage
                     * `datastore` - Datastore
                     * `platform` - Platform
-                    * `software` - Software
+                    * `software` - Software (accepted alias; stored as software_or_service)
+                    * `software_or_service` - Software or service
+                    * `cpu` - CPU
                     * `load_balancer` - Load Balancer
                     * `load_balancer_virtual_server` - Load Balancer Virtual Server
                   enum:
@@ -101,10 +105,12 @@ post:
                     - compute
                     - memory
                     - cores
+                    - cpu
                     - storage
                     - datastore
                     - platform
                     - software
+                    - software_or_service
                     - load_balancer
                     - load_balancer_virtual_server
                 priceUnit:
@@ -160,7 +166,15 @@ post:
                   example: linux
                 software:
                   type: string
-                  description: Software.  Required for software price type
+                  description: |
+                    Software or service name for software prices.
+                    Accepted as an alias for `softwareOrService`; when `priceType`
+                    is `software`, the API stores type `software_or_service`.
+                softwareOrService:
+                  type: string
+                  description: |
+                    Software or service name. Preferred request field used by the UI.
+                    Required when price type is software / software_or_service.
                 volumeType:
                   type: object
                   properties:
@@ -190,13 +204,11 @@ post:
             allOf:
             - type: object
               properties:
-                price:
-                  $ref: ../components/schemas/price.yaml
+                id:
+                  type: integer
+                  format: int64
+                  description: ID of the created price
             - $ref: ../components/schemas/200-success.yaml
-          examples:
-            Price Response:
-              value:
-                $ref: ../components/examples/priceSuccess.json
     '4XX':
       $ref: ../components/responses/4xx.yaml
     '5XX':

--- a/paths/api@prices@currencies.yaml
+++ b/paths/api@prices@currencies.yaml
@@ -1,0 +1,37 @@
+get:
+  summary: List price currencies
+  description: |
+    Lists ISO currency codes available when creating or updating prices.
+    Used by the Administration Plans price editor.
+  operationId: listPriceCurrencies
+  tags:
+    - Prices
+  responses:
+    '200':
+      description: Successful Request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              currencies:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      description: Currency code
+                      example: USD
+                    value:
+                      type: string
+                      description: Currency code (same as name)
+                      example: USD
+                    code:
+                      type: string
+                      description: Currency code (same as name)
+                      example: USD
+    '4XX':
+      $ref: ../components/responses/4xx.yaml
+    '5XX':
+      $ref: ../components/responses/5xx.yaml

--- a/paths/api@prices@currencies.yaml
+++ b/paths/api@prices@currencies.yaml
@@ -2,7 +2,6 @@ get:
   summary: List price currencies
   description: |
     Lists ISO currency codes available when creating or updating prices.
-    Used by the Administration Plans price editor.
   operationId: listPriceCurrencies
   tags:
     - Prices

--- a/paths/api@prices@id.yaml
+++ b/paths/api@prices@id.yaml
@@ -151,7 +151,7 @@ put:
                 softwareOrService:
                   type: string
                   description: |
-                    Software or service name. Preferred request field used by the UI.
+                    Software or service name.
                     Required when price type is software / software_or_service.
                 volumeType:
                   type: object
@@ -177,8 +177,8 @@ put:
               type: boolean
               description: |
                 When true (or the string `on`) and the update succeeds, triggers
-                asynchronous reprocessing of price usage changes. Sent at the
-                request root by the UI (not inside `price`).
+                asynchronous reprocessing of price usage changes. Request-root field
+                (not inside `price`).
               example: true
   responses:
     '200':

--- a/paths/api@prices@id.yaml
+++ b/paths/api@prices@id.yaml
@@ -75,7 +75,6 @@ put:
                     * `platform` - Platform
                     * `software` - Software (accepted alias; stored as software_or_service)
                     * `software_or_service` - Software or service
-                    * `cpu` - CPU
                     * `load_balancer` - Load Balancer
                     * `load_balancer_virtual_server` - Load Balancer Virtual Server
                   enum:
@@ -83,7 +82,6 @@ put:
                     - compute
                     - memory
                     - cores
-                    - cpu
                     - storage
                     - datastore
                     - platform

--- a/paths/api@prices@id.yaml
+++ b/paths/api@prices@id.yaml
@@ -29,6 +29,10 @@ put:
   summary: Updates a Price
   description: |
     Updates a price.
+
+    `code` and `account` on the request are ignored; the existing price values are kept.
+    Software prices may send `software` or `softwareOrService`. Request `priceType`
+    value `software` is stored as `software_or_service`.
   operationId: updatePrices
   tags:
     - Prices
@@ -69,7 +73,9 @@ put:
                     * `storage` - Storage
                     * `datastore` - Datastore
                     * `platform` - Platform
-                    * `software` - Software
+                    * `software` - Software (accepted alias; stored as software_or_service)
+                    * `software_or_service` - Software or service
+                    * `cpu` - CPU
                     * `load_balancer` - Load Balancer
                     * `load_balancer_virtual_server` - Load Balancer Virtual Server
                   enum:
@@ -77,10 +83,12 @@ put:
                     - compute
                     - memory
                     - cores
+                    - cpu
                     - storage
                     - datastore
                     - platform
                     - software
+                    - software_or_service
                     - load_balancer
                     - load_balancer_virtual_server
                 priceUnit:
@@ -136,7 +144,15 @@ put:
                   example: linux
                 software:
                   type: string
-                  description: Software.  Required for software price type
+                  description: |
+                    Software or service name for software prices.
+                    Accepted as an alias for `softwareOrService`; when `priceType`
+                    is `software`, the API stores type `software_or_service`.
+                softwareOrService:
+                  type: string
+                  description: |
+                    Software or service name. Preferred request field used by the UI.
+                    Required when price type is software / software_or_service.
                 volumeType:
                   type: object
                   properties:
@@ -157,22 +173,20 @@ put:
                 crossCloudApply:
                   type: boolean
                   description: Apply price across clouds, optional true/false flag for datastore price type
+            restartUsage:
+              type: boolean
+              description: |
+                When true (or the string `on`) and the update succeeds, triggers
+                asynchronous reprocessing of price usage changes. Sent at the
+                request root by the UI (not inside `price`).
+              example: true
   responses:
     '200':
       description: Successful Request
       content:
         application/json:
           schema:
-            allOf:
-            - type: object
-              properties:
-                price:
-                  $ref: ../components/schemas/price.yaml
-            - $ref: ../components/schemas/200-success.yaml
-          examples:
-            Price Response:
-              value:
-                $ref: ../components/examples/priceSuccess.json
+            $ref: ../components/schemas/200-success.yaml
     '4XX':
       $ref: ../components/responses/4xx.yaml
     '5XX':


### PR DESCRIPTION
- `price.account` response type is `{id,name}` (not string)
- Create/update accept `softwareOrService` and `software` / `software_or_service` price types
- Update documents root `restartUsage`; create/update success shapes match `shared/save`
- List filters: `code`, `order`, `priceUnit`; expand `priceType` enums
- Add `GET /api/prices/currencies` (price editor)
