### PR TITLE
Align policies OpenAPI with Admin Policies UI create/update

### DIFF
--- a/components/schemas/policyCreate.yaml
+++ b/components/schemas/policyCreate.yaml
@@ -17,11 +17,9 @@ properties:
       Policy type. Accepts `{ id }`, `{ code }`, or a bare type code string.
     properties:
       id:
-        oneOf:
-          - type: integer
-            format: int64
-          - type: string
-        description: Policy type ID. Accepts string or integer.
+        type: integer
+        format: int64
+        description: Policy type ID
       code:
         type: string
         description: The policy type code. See `Retrieves all Policy Types` endpoint for listing.
@@ -516,20 +514,15 @@ properties:
           - Plan
       - type: 'null'
   refId:
-    description: Scope object ID (`group`,`cloud`,`user`, etc). Accepts string or integer.
-    oneOf:
-      - type: integer
-        format: int64
-      - type: string
+    type: integer
+    format: int64
+    description: Scope object ID (`group`,`cloud`,`user`, etc)
   accounts:
     type: array
-    description: |
-      Tenant account IDs to scope the policy to. Accepts string or integer IDs.
+    description: Array of tenants to scope the policy to
     items:
-      oneOf:
-        - type: integer
-          format: int64
-        - type: string
+      type: integer
+      format: int64
   eachUser:
     type: boolean
     description: Apply individually to each user in role.  Only when `refType` equals `Role`

--- a/components/schemas/policyCreate.yaml
+++ b/components/schemas/policyCreate.yaml
@@ -14,15 +14,14 @@ properties:
   policyType:
     type: object
     description: |
-      Policy type selector. The UI sends `{ id }`; the API also accepts `{ code }`
-      or a bare type code string.
+      Policy type. Accepts `{ id }`, `{ code }`, or a bare type code string.
     properties:
       id:
         oneOf:
           - type: integer
             format: int64
           - type: string
-        description: Policy type ID (used by the Administration Policies UI)
+        description: Policy type ID. Accepts string or integer.
       code:
         type: string
         description: The policy type code. See `Retrieves all Policy Types` endpoint for listing.
@@ -517,7 +516,7 @@ properties:
           - Plan
       - type: 'null'
   refId:
-    description: Scope object ID (`group`,`cloud`,`user`, etc). UI sends a string; integers are also accepted.
+    description: Scope object ID (`group`,`cloud`,`user`, etc). Accepts string or integer.
     oneOf:
       - type: integer
         format: int64
@@ -525,8 +524,7 @@ properties:
   accounts:
     type: array
     description: |
-      Tenant account IDs to scope the policy to. The UI sends string IDs;
-      integers are also accepted.
+      Tenant account IDs to scope the policy to. Accepts string or integer IDs.
     items:
       oneOf:
         - type: integer

--- a/components/schemas/policyCreate.yaml
+++ b/components/schemas/policyCreate.yaml
@@ -13,8 +13,7 @@ properties:
     description: A description for the policy
   policyType:
     type: object
-    description: |
-      Policy type. Accepts `{ id }`, `{ code }`, or a bare type code string.
+    description: Policy type. Accepts `{ id }` or `{ code }`.
     properties:
       id:
         type: integer

--- a/components/schemas/policyCreate.yaml
+++ b/components/schemas/policyCreate.yaml
@@ -13,7 +13,16 @@ properties:
     description: A description for the policy
   policyType:
     type: object
+    description: |
+      Policy type selector. The UI sends `{ id }`; the API also accepts `{ code }`
+      or a bare type code string.
     properties:
+      id:
+        oneOf:
+          - type: integer
+            format: int64
+          - type: string
+        description: Policy type ID (used by the Administration Policies UI)
       code:
         type: string
         description: The policy type code. See `Retrieves all Policy Types` endpoint for listing.
@@ -508,15 +517,21 @@ properties:
           - Plan
       - type: 'null'
   refId:
-    type: integer
-    format: int64
-    description: Scope object ID (`group`,`cloud`,`user`, etc)
+    description: Scope object ID (`group`,`cloud`,`user`, etc). UI sends a string; integers are also accepted.
+    oneOf:
+      - type: integer
+        format: int64
+      - type: string
   accounts:
     type: array
-    description: Array of tenants to scope the policy to
+    description: |
+      Tenant account IDs to scope the policy to. The UI sends string IDs;
+      integers are also accepted.
     items:
-      type: integer
-      format: int64
+      oneOf:
+        - type: integer
+          format: int64
+        - type: string
   eachUser:
     type: boolean
     description: Apply individually to each user in role.  Only when `refType` equals `Role`

--- a/components/schemas/policyUpdate.yaml
+++ b/components/schemas/policyUpdate.yaml
@@ -462,20 +462,15 @@ properties:
       - Network
       - Plan
   refId:
-    description: Scope object ID (`group`,`cloud`,`user`, etc). Accepts string or integer.
-    oneOf:
-      - type: integer
-        format: int64
-      - type: string
+    type: integer
+    format: int64
+    description: Scope object ID (`group`,`cloud`,`user`, etc)
   accounts:
     type: array
-    description: |
-      Tenant account IDs to scope the policy to. Accepts string or integer IDs.
+    description: Array of tenants to scope the policy to
     items:
-      oneOf:
-        - type: integer
-          format: int64
-        - type: string
+      type: integer
+      format: int64
   eachUser:
     type: boolean
     description: Apply individually to each user in role.  Only when `refType` equals `Role`

--- a/components/schemas/policyUpdate.yaml
+++ b/components/schemas/policyUpdate.yaml
@@ -462,7 +462,7 @@ properties:
       - Network
       - Plan
   refId:
-    description: Scope object ID (`group`,`cloud`,`user`, etc). UI sends a string; integers are also accepted.
+    description: Scope object ID (`group`,`cloud`,`user`, etc). Accepts string or integer.
     oneOf:
       - type: integer
         format: int64
@@ -470,8 +470,7 @@ properties:
   accounts:
     type: array
     description: |
-      Tenant account IDs to scope the policy to. The UI sends string IDs;
-      integers are also accepted.
+      Tenant account IDs to scope the policy to. Accepts string or integer IDs.
     items:
       oneOf:
         - type: integer

--- a/components/schemas/policyUpdate.yaml
+++ b/components/schemas/policyUpdate.yaml
@@ -462,15 +462,21 @@ properties:
       - Network
       - Plan
   refId:
-    type: integer
-    format: int64
-    description: Scope object ID (`group`,`cloud`,`user`, etc)
+    description: Scope object ID (`group`,`cloud`,`user`, etc). UI sends a string; integers are also accepted.
+    oneOf:
+      - type: integer
+        format: int64
+      - type: string
   accounts:
     type: array
-    description: Array of tenants to scope the policy to
+    description: |
+      Tenant account IDs to scope the policy to. The UI sends string IDs;
+      integers are also accepted.
     items:
-      type: integer
-      format: int64
+      oneOf:
+        - type: integer
+          format: int64
+        - type: string
   eachUser:
     type: boolean
     description: Apply individually to each user in role.  Only when `refType` equals `Role`

--- a/paths/api@policies.yaml
+++ b/paths/api@policies.yaml
@@ -42,6 +42,10 @@ post:
   summary: Creates a Policy
   description: |
     Creates a policy.
+
+    The Administration Policies UI posts `policy.policyType.id` (string or number).
+    `policy.policyType.code`, a bare type-code string, `refId` as string, and
+    `accounts` as string IDs are also accepted.
   operationId: addPolicies
   tags:
     - Policies

--- a/paths/api@policies.yaml
+++ b/paths/api@policies.yaml
@@ -43,8 +43,7 @@ post:
   description: |
     Creates a policy.
 
-    `policy.policyType` accepts `{ id }` (string or integer), `{ code }`, or a bare type-code string.
-    `refId` and `accounts` items accept string or integer.
+    `policy.policyType` accepts `{ id }`, `{ code }`, or a bare type-code string.
   operationId: addPolicies
   tags:
     - Policies

--- a/paths/api@policies.yaml
+++ b/paths/api@policies.yaml
@@ -43,9 +43,8 @@ post:
   description: |
     Creates a policy.
 
-    The Administration Policies UI posts `policy.policyType.id` (string or number).
-    `policy.policyType.code`, a bare type-code string, `refId` as string, and
-    `accounts` as string IDs are also accepted.
+    `policy.policyType` accepts `{ id }` (string or integer), `{ code }`, or a bare type-code string.
+    `refId` and `accounts` items accept string or integer.
   operationId: addPolicies
   tags:
     - Policies

--- a/paths/api@policies.yaml
+++ b/paths/api@policies.yaml
@@ -42,8 +42,7 @@ post:
   summary: Creates a Policy
   description: |
     Creates a policy.
-
-    `policy.policyType` accepts `{ id }`, `{ code }`, or a bare type-code string.
+    `policy.policyType` accepts `{ id }` or `{ code }`.
   operationId: addPolicies
   tags:
     - Policies

--- a/paths/api@policies@id.yaml
+++ b/paths/api@policies@id.yaml
@@ -126,7 +126,6 @@ put:
   summary: Updates a Policy
   description: |
     Updates a policy.
-
     Policy type is not changed on update.
   operationId: updatePolicies
   tags:

--- a/paths/api@policies@id.yaml
+++ b/paths/api@policies@id.yaml
@@ -126,6 +126,9 @@ put:
   summary: Updates a Policy
   description: |
     Updates a policy.
+
+    The Administration Policies UI may send `refId` and `accounts` as strings.
+    Policy type is not changed on update.
   operationId: updatePolicies
   tags:
     - Policies

--- a/paths/api@policies@id.yaml
+++ b/paths/api@policies@id.yaml
@@ -127,7 +127,7 @@ put:
   description: |
     Updates a policy.
 
-    `refId` and `accounts` items accept string or integer. Policy type is not changed on update.
+    Policy type is not changed on update.
   operationId: updatePolicies
   tags:
     - Policies

--- a/paths/api@policies@id.yaml
+++ b/paths/api@policies@id.yaml
@@ -127,8 +127,7 @@ put:
   description: |
     Updates a policy.
 
-    The Administration Policies UI may send `refId` and `accounts` as strings.
-    Policy type is not changed on update.
+    `refId` and `accounts` items accept string or integer. Policy type is not changed on update.
   operationId: updatePolicies
   tags:
     - Policies


### PR DESCRIPTION
- Document `policy.policyType.id` (UI create); code still accepted
- `refId` and `accounts` accept string or integer (UI + PolicyService)
