### PR TITLE
Align accounts OpenAPI with Admin Tenants UI create/update

### DIFF
--- a/components/schemas/tenant.yaml
+++ b/components/schemas/tenant.yaml
@@ -26,7 +26,9 @@ properties:
       - string
       - 'null'
   accountName:
-    type: string
+    type:
+      - string
+      - 'null'
   active:
     type: boolean
   master:
@@ -51,6 +53,9 @@ properties:
       id:
         type: integer
         format: int64
+      name:
+        type: string
+        description: Role authority (same value as `authority`)
       authority:
         type: string
       description:

--- a/components/schemas/tenant.yaml
+++ b/components/schemas/tenant.yaml
@@ -55,7 +55,7 @@ properties:
         format: int64
       name:
         type: string
-        description: Role authority (same value as `authority`)
+        description: Role name
       authority:
         type: string
       description:

--- a/paths/api@accounts.yaml
+++ b/paths/api@accounts.yaml
@@ -64,21 +64,31 @@ post:
                     - 'null'
                   description: Description
                   example: Testing Tenant Creation
+                active:
+                  type: boolean
+                  description: Whether the tenant is active
+                  example: true
                 parentAccount:
                   type: object
                   description: Parent Account. This specifies the parent account for the new tenant. By default this will be the current user's tenant. This is only available to master tenant users.
                   properties:
                     id:
-                      type: integer
-                      format: int64
+                      description: Parent tenant ID. UI option values are strings; integers are also accepted.
+                      oneOf:
+                        - type: integer
+                          format: int64
+                        - type: string
                       example: 1
                 role:
                   type: object
                   description: Tenant Base Role. This restricts the access available to this tenant's roles and users. The Options API `/api/options/roles?roleType=account&tenantId=1` can be used to see which options are available.
                   properties:
                     id:
-                      type: integer
-                      format: int64
+                      description: Base role ID. UI option values are strings; integers are also accepted.
+                      oneOf:
+                        - type: integer
+                          format: int64
+                        - type: string
                       example: 3
                 subdomain:
                   type:
@@ -88,6 +98,21 @@ post:
                   example: tt
                 currency:
                   $ref: ../components/schemas/CurrencyCode.yaml
+                accountNumber:
+                  type:
+                    - string
+                    - 'null'
+                  description: Account number
+                accountName:
+                  type:
+                    - string
+                    - 'null'
+                  description: Account name
+                customerNumber:
+                  type:
+                    - string
+                    - 'null'
+                  description: Customer number
   responses:
     '200':
       description: Tenant Object

--- a/paths/api@accounts.yaml
+++ b/paths/api@accounts.yaml
@@ -73,7 +73,7 @@ post:
                   description: Parent Account. This specifies the parent account for the new tenant. By default this will be the current user's tenant. This is only available to master tenant users.
                   properties:
                     id:
-                      description: Parent tenant ID. UI option values are strings; integers are also accepted.
+                      description: Parent tenant ID. Accepts string or integer.
                       oneOf:
                         - type: integer
                           format: int64
@@ -84,7 +84,7 @@ post:
                   description: Tenant Base Role. This restricts the access available to this tenant's roles and users. The Options API `/api/options/roles?roleType=account&tenantId=1` can be used to see which options are available.
                   properties:
                     id:
-                      description: Base role ID. UI option values are strings; integers are also accepted.
+                      description: Base role ID. Accepts string or integer.
                       oneOf:
                         - type: integer
                           format: int64

--- a/paths/api@accounts@id.yaml
+++ b/paths/api@accounts@id.yaml
@@ -41,6 +41,7 @@ put:
             - account
           properties:
             account:
+              type: object
               description: Payload for updating an existing tenant
               properties:
                 name:
@@ -51,13 +52,19 @@ put:
                     - string
                     - 'null'
                   description: Description
+                active:
+                  type: boolean
+                  description: Whether the tenant is active
                 role:
                   type: object
                   description: Tenant Base Role. This restricts the access available to this tenant's roles and users.
                   properties:
                     id:
-                      type: integer
-                      format: int64
+                      description: Base role ID. UI option values are strings; integers are also accepted.
+                      oneOf:
+                        - type: integer
+                          format: int64
+                        - type: string
                 subdomain:
                   type:
                     - string
@@ -65,18 +72,33 @@ put:
                   description: The subdomain. This will be part of the login URL and username for sub tenant users.
                 currency:
                   $ref: ../components/schemas/CurrencyCode.yaml
+                accountNumber:
+                  type:
+                    - string
+                    - 'null'
+                  description: Account number
+                accountName:
+                  type:
+                    - string
+                    - 'null'
+                  description: Account name
+                customerNumber:
+                  type:
+                    - string
+                    - 'null'
+                  description: Customer number
   responses:
     '200':
       description: Tenant Object
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              account:
-                allOf:
-                  - $ref: ../components/schemas/tenant.yaml
-                  - $ref: ../components/schemas/200-success.yaml
+            allOf:
+              - type: object
+                properties:
+                  account:
+                    $ref: ../components/schemas/tenant.yaml
+              - $ref: ../components/schemas/200-success.yaml
           examples:
             Tenant Response:
               value:

--- a/paths/api@accounts@id.yaml
+++ b/paths/api@accounts@id.yaml
@@ -60,7 +60,7 @@ put:
                   description: Tenant Base Role. This restricts the access available to this tenant's roles and users.
                   properties:
                     id:
-                      description: Base role ID. UI option values are strings; integers are also accepted.
+                      description: Base role ID. Accepts string or integer.
                       oneOf:
                         - type: integer
                           format: int64


### PR DESCRIPTION
- Document UI-bound fields: `active`, `accountName`, `accountNumber`, `customerNumber`
- Accept string or int for `parentAccount.id` / `role.id` (option select values)
- Add `role.name` on tenant response (gson); nullable `accountName`
- Fix update 200 envelope: `success` is sibling of `account`, not nested under it
