### PR TITLE
Tighten clients OpenAPI types to public contract

### DIFF
--- a/components/schemas/client.yaml
+++ b/components/schemas/client.yaml
@@ -2,9 +2,8 @@ type: object
 description: OAuth client as returned by ClientsController gson (`_client.gson`).
 properties:
   id:
-    type:
-      - integer
-      - string
+    type: integer
+    format: int64
     description: Client database id
     example: 2
   clientId:
@@ -12,17 +11,12 @@ properties:
     description: OAuth client identifier
     example: morph-cli
   clientSecret:
-    type:
-      - string
-      - 'null'
+    type: string
     description: |
       Masked client secret when a secret is set. Omitted when no secret is configured.
-      Masking uses the standard secret mask (not the raw secret value).
     example: '************'
   clientSecretHash:
-    type:
-      - string
-      - 'null'
+    type: string
     description: |
       Hash of the client secret when a secret is set. Omitted when no secret is configured.
     example: a1b2c3d4e5f6
@@ -30,12 +24,14 @@ properties:
     type:
       - integer
       - 'null'
+    format: int64
     description: Access token lifetime in seconds
     example: 43200
   refreshTokenValiditySeconds:
     type:
       - integer
       - 'null'
+    format: int64
     description: Refresh token lifetime in seconds
     example: 43200
   authorizedGrantTypes:
@@ -74,5 +70,5 @@ properties:
     type: boolean
     description: |
       True when the client is a system client (`removable != true`).
-      System clients cannot be deleted and have restricted editable fields in the UI.
+      System clients cannot be deleted and have restricted editable fields.
     example: false

--- a/components/schemas/client.yaml
+++ b/components/schemas/client.yaml
@@ -1,5 +1,5 @@
 type: object
-description: OAuth client as returned by ClientsController gson (`_client.gson`).
+description: OAuth client.
 properties:
   id:
     type: integer

--- a/components/schemas/clientUpdate.yaml
+++ b/components/schemas/clientUpdate.yaml
@@ -12,38 +12,28 @@ properties:
     description: OAuth client identifier (required on create)
     example: Test Client
   clientSecret:
-    type:
-      - string
-      - 'null'
+    type: string
     description: |
       Client secret. On update, values starting with `********` are ignored so the existing
       secret is retained.
     example: thisIsaClientSecretKeyPhrase
   accessTokenValiditySeconds:
-    type:
-      - integer
-      - string
-      - 'null'
-    description: Access token lifetime in seconds (must be a number greater than 0 when provided)
+    type: integer
+    format: int64
+    description: Access token lifetime in seconds (must be greater than 0 when provided)
     example: 43200
   refreshTokenValiditySeconds:
-    type:
-      - integer
-      - string
-      - 'null'
-    description: Refresh token lifetime in seconds (must be a number greater than 0 when provided)
+    type: integer
+    format: int64
+    description: Refresh token lifetime in seconds (must be greater than 0 when provided)
     example: 43200
   redirectUris:
-    description: |
-      Redirect URIs. Accepts a JSON array of strings or a comma-separated string.
-    oneOf:
-      - type: array
-        items:
-          type: string
-        example:
-          - https://example.com/callback
-      - type: string
-        example: https://example.com/callback, https://example.com/other
+    type: array
+    description: Redirect URIs for the authorization code flow
+    items:
+      type: string
+    example:
+      - https://example.com/callback
   requireConsent:
     type: boolean
     description: Whether the client requires user consent


### PR DESCRIPTION
- `client.id`: `integer` + `format: int64` only (drop `integer|string` outlier)
- Token validity (response): keep `integer|'null'`, add `format: int64`
- Token validity (request): `integer` + `format: int64` only (drop `string|null`)
- Secrets: plain `string` (omitted when unset)
- `redirectUris` (request): `string[]` only (drop comma-separated string `oneOf`)
- Minor: drop “in the UI” from `system` field description (delete/update limits are server-side)
