### PR TITLE
Tighten log-settings OpenAPI types for Settings UI

### DIFF
--- a/components/examples/logSettings.json
+++ b/components/examples/logSettings.json
@@ -1,7 +1,7 @@
 {
     "logSettings": {
         "enabled": true,
-        "retentionDays": "7",
+        "retentionDays": 7,
         "minimumLogLevel": null,
         "syslogRules": [],
         "integrations": []

--- a/components/schemas/logSettings.yaml
+++ b/components/schemas/logSettings.yaml
@@ -3,10 +3,9 @@ properties:
   enabled:
     type: boolean
   retentionDays:
+    type: integer
+    format: int64
     description: Log retention period in days
-    oneOf:
-      - type: string
-      - type: integer
   minimumLogLevel:
     type:
       - string
@@ -18,9 +17,7 @@ properties:
       - WARN
       - ERROR
   syslogRules:
-    type:
-      - array
-      - 'null'
+    type: array
     items:
       type: object
       properties:
@@ -53,4 +50,3 @@ properties:
           type:
             - string
             - 'null'
-            - integer

--- a/components/schemas/logSettingsUpdate.yaml
+++ b/components/schemas/logSettingsUpdate.yaml
@@ -1,0 +1,21 @@
+type: object
+description: |
+  Writable log settings fields under the required `logSettings` object on PUT /api/log-settings.
+  Syslog rules and integrations are managed via their dedicated endpoints.
+properties:
+  enabled:
+    type: boolean
+  retentionDays:
+    type: integer
+    format: int64
+    description: Log retention period in days
+  minimumLogLevel:
+    type:
+      - string
+      - 'null'
+    enum:
+      - null
+      - DEBUG
+      - INFO
+      - WARN
+      - ERROR

--- a/paths/api@log-settings.yaml
+++ b/paths/api@log-settings.yaml
@@ -33,9 +33,11 @@ put:
       application/json:
         schema:
           type: object
+          required:
+            - logSettings
           properties:
             logSettings:
-              $ref: ../components/schemas/logSettings.yaml
+              $ref: ../components/schemas/logSettingsUpdate.yaml
   responses:
     '200':
       description: Successful Response

--- a/paths/api@log-settings@integrations@name.yaml
+++ b/paths/api@log-settings@integrations@name.yaml
@@ -28,9 +28,8 @@ put:
                 host:
                   type: string
                 port:
-                  oneOf:
-                    - type: string
-                    - type: integer
+                  type: integer
+                  format: int64
   responses:
     '200':
       description: Successful Response


### PR DESCRIPTION
- `retentionDays` as integer only (no string|integer)
- Separate writable PUT schema (`logSettingsUpdate`) for enabled / retentionDays / minimumLogLevel
- Integration port: integer on request; drop string|integer dual on path
- Response example uses numeric retentionDays
