### PR TITLE
Add imageId to the HVM and VMware instance config schemas

### DIFF
--- a/components/schemas/instancesConfigHVM.yaml
+++ b/components/schemas/instancesConfigHVM.yaml
@@ -1,6 +1,10 @@
 title: HVM Instance Configuration
 type: object
 properties:
+  imageId:
+    type: integer
+    format: int64
+    description: The id of the virtual image to provision the instance from. Takes precedence over the image configured on the instance type layout.
   noAgent:
     type:
       - boolean

--- a/components/schemas/instancesConfigVMWare.yaml
+++ b/components/schemas/instancesConfigVMWare.yaml
@@ -40,6 +40,10 @@ properties:
       - 'null'
     description: Create user
     default: false
+  imageId:
+    type: integer
+    format: int64
+    description: The id of the virtual image to provision the instance from. Takes precedence over the image configured on the instance type layout, and over `template`.
   template:
     description: Image ID. This is the ID of a Virtual Image.
     type: integer


### PR DESCRIPTION
Closes MORPH-16314.

## Why

The platform resolves an instance's provisioning image from `config.imageId` first, then `config.template`, and falls back to the image configured on the instance type layout. That resolution is the same for every provision type.

The spec did not reflect that. `imageId` was declared only on the BMaaS config schema; VMware declared only `template`; HVM had no image field at all. A caller reading the spec would conclude an image cannot be selected on HVM, which is not the case.

## What changed

`imageId` (integer, int64) added to:

- `components/schemas/instancesConfigHVM.yaml`
- `components/schemas/instancesConfigVMWare.yaml`

**Optional on both.** An image configured on the layout is the normal path; only overriding it is new. This differs deliberately from the BMaaS schema, where `imageId` is `required`.

`template` is left in place on the VMware schema. It remains valid API surface and is still accepted by the resolver.

## Why `imageId` rather than reusing `template`

Both reach the same resolution logic, but they are not equivalent:

- `imageId` takes precedence over `template`
- `imageId` is a plain scalar. `template` additionally accepts an object form carrying a `value` member, which is what the UI form submits, so its type is not cleanly expressible
- `imageId` matches the existing BMaaS declaration, so one field name now covers all three config schemas

Declaring `imageId` on both means the field a caller should set is the same one everywhere.

## Verification

Confirmed against a live appliance before the spec was written. Creating an instance on HVM with `config = { imageId = <id> }` returns that value unchanged when the instance is read back:

```
config keys: [createBackup, customOptions, imageId, layoutSize,
              lbInstances, memoryDisplay, resourcePoolId]

imageId  = 1405        <- echoed verbatim
template = <ABSENT>    <- no normalisation
```

The provision attempt then failed with "Cloud files could not be found for <image name>" — the named image was resolved and used, which is what the change needed to establish.

## Consumers

The Terraform provider change that consumes this is raised separately and is self-contained: it regenerates and vendors its SDK from a local copy of this spec, so it does not wait on this PR. This PR still needs to land so the two trees do not drift.
