### PR TITLE
MORPH-15828: Document object form of storageType on volumes

### DIFF
--- a/components/schemas/instanceCreateVolume.yaml
+++ b/components/schemas/instanceCreateVolume.yaml
@@ -27,11 +27,23 @@ properties:
     format: int64
     description: Can be used to select pre-existing LV choices from Morpheus.
   storageType:
-    type:
-      - integer
-      - 'null'
-    format: int64
-    description: Identifier for LV type
+    oneOf:
+      - type:
+          - integer
+          - 'null'
+        format: int64
+      - type: object
+        properties:
+          id:
+            type: integer
+            format: int64
+            description: The id of the LV type. Not guaranteed to be stable across appliances; prefer `code` when known.
+          code:
+            type: string
+            description: The code of the LV type, eg. `"standard"` or `"io1"`. Takes precedence over `id` when both are provided.
+    description: |-
+      Identifier for LV type. Can be a plain numeric id (legacy form), or an object with `id` and/or `code`,
+      eg. `{"code": "standard"}`. When both `id` and `code` are supplied, `code` takes precedence.
   datastoreId:
     anyOf:
       - type:


### PR DESCRIPTION
## Change
`storageType` on a volume payload (used by instance create, resize, clone, host resize, and catalog-item scribe) now accepts either:
- a plain numeric id (unchanged, backward compatible), or
- an object like `{id, code}`, matching the existing `instanceType`/`taskType` convention.

Documents that `code` takes precedence over `id` when both are supplied.

Ref: MORPH-15828

Companion API change: HPE-EMU/morpheus-ui#5644