### PR TITLE
Expose the full filter set on GET /api/virtual-images

### DIFF
--- a/components/parameters/imageType.yaml
+++ b/components/parameters/imageType.yaml
@@ -1,6 +1,20 @@
 name: imageType
 in: query
-description: Filter by image type code, "vmware", "ami", etc
+description: >-
+  Filter by image type code. Repeatable — supply the parameter more than once
+  to match any of several types, for example
+  `?imageType=qcow2&imageType=raw`.
+
+
+  Some values are aliases matching several underlying types rather than an
+  exact code: `vmware` matches `vmware`, `ovf` and `vmdk`; `virtualbox`
+  matches `vdi` and `virtualbox`. Any other value, such as `qcow2`, `raw` or
+  `iso`, is matched exactly.
 schema:
-  type: string
-example: "vmware"
+  type: array
+  items:
+    type: string
+explode: true
+example:
+  - qcow2
+  - raw

--- a/components/parameters/includeSystemImage.yaml
+++ b/components/parameters/includeSystemImage.yaml
@@ -1,0 +1,13 @@
+name: includeSystemImage
+in: query
+description: >-
+  Include system images alongside non-system images. System images are
+  excluded unless this is `true`.
+
+
+  Takes precedence over `filterType`: if this parameter is supplied,
+  `filterType` is ignored. `systemImage` in turn takes precedence over this
+  parameter when both are supplied.
+schema:
+  type: boolean
+example: true

--- a/components/parameters/systemImage.yaml
+++ b/components/parameters/systemImage.yaml
@@ -1,0 +1,12 @@
+name: systemImage
+in: query
+description: >-
+  Filter on whether an image is a system image. `true` returns only system
+  images, `false` only non-system images.
+
+
+  Takes precedence over `filterType`: if this parameter is supplied,
+  `filterType` is ignored entirely.
+schema:
+  type: boolean
+example: false

--- a/components/parameters/virtualImageDescription.yaml
+++ b/components/parameters/virtualImageDescription.yaml
@@ -1,0 +1,16 @@
+name: description
+in: query
+description: >-
+  Filter by description. Repeatable — supply the parameter more than once to
+  match any of several descriptions.
+
+
+  Matching is a case-insensitive SQL `like`, so `%` acts as a wildcard, for
+  example `?description=ubuntu%`. This is not a regular expression.
+schema:
+  type: array
+  items:
+    type: string
+explode: true
+example:
+  - ubuntu%

--- a/components/parameters/virtualImageId.yaml
+++ b/components/parameters/virtualImageId.yaml
@@ -1,0 +1,14 @@
+name: id
+in: query
+description: >-
+  Filter by virtual image ID. Repeatable — supply the parameter more than once
+  to fetch several images in one request, for example `?id=170332&id=127280`.
+schema:
+  type: array
+  items:
+    type: integer
+    format: int64
+explode: true
+example:
+  - 170332
+  - 127280

--- a/paths/api@virtual-images.yaml
+++ b/paths/api@virtual-images.yaml
@@ -12,6 +12,12 @@ get:
     - $ref: ../components/parameters/lastUpdated.yaml
     - $ref: ../components/parameters/filterType.yaml
     - $ref: ../components/parameters/imageType.yaml
+    - $ref: ../components/parameters/virtualImageId.yaml
+    - $ref: ../components/parameters/virtualImageDescription.yaml
+    - $ref: ../components/parameters/systemImage.yaml
+    - $ref: ../components/parameters/includeSystemImage.yaml
+    - $ref: ../components/parameters/sort.yaml
+    - $ref: ../components/parameters/direction.yaml
     - $ref: ../components/parameters/tags.yaml
     - $ref: ../components/parameters/labels.yaml
     - $ref: ../components/parameters/allLabels.yaml


### PR DESCRIPTION
## Summary

`GET /api/virtual-images` accepts several query parameters that the specification did not describe, so a generated client could not reach them. This adds them, and corrects three that the endpoint reads as repeatable.

`VirtualImagesController.buildCriteriaClosure` handles all of the following; only the first group was previously documented.

## Added parameters

| Parameter | Type | Notes |
|---|---|---|
| `id` | integer, repeatable | Fetch specific images by id. |
| `description` | string, repeatable | Case-insensitive `like`; `%` is the wildcard. |
| `systemImage` | boolean | Overrides `filterType`. |
| `includeSystemImage` | boolean | Overrides `filterType`; overridden by `systemImage`. |
| `sort` | string | Property to order by. |
| `direction` | string | `asc` or `desc`. |

## Changed to repeatable

`id`, `description` and `imageType` are read with `params.list(...)` and their values ORed, so each is now typed as an array with `explode: true`. Asking for `imageType=qcow2&imageType=raw` in one request returns either.

`imageType` values are also documented as the aliases they are: `vmware` matches `vmware`, `ovf` and `vmdk`; `virtualbox` matches `vdi` and `virtualbox`; any other value is exact.

## Scoping

`id` and `description` are given virtual-image-specific parameter files rather than widening the shared `id.yaml` and `description.yaml`, which are scalars used by unrelated paths. `imageType` is referenced only by this endpoint and is widened in place. `name` is deliberately left scalar: it is shared by many paths, and nothing needs it repeatable here.

## Precedence

`systemImage` and `includeSystemImage` override `filterType` entirely rather than narrowing alongside it — an `if/else` in the controller — and `systemImage` in turn overrides `includeSystemImage`. That is documented on both parameters, since supplying one silently disables the other.
