### PR TITLE
Add tenant create/update writable fields, role endpoint, and widen currency enum (MORPH-16404)

### DIFF
--- a/components/schemas/CurrencyCode.yaml
+++ b/components/schemas/CurrencyCode.yaml
@@ -1,14 +1,19 @@
 type: string
 description: Currency Code (ISO 4217)
 enum:
+  - AED
+  - ARS
   - AUD
+  - AZN
   - BGN
   - BRL
+  - BWP
   - CAD
   - CHF
   - CLF
   - CLP
   - CNY
+  - COP
   - CZK
   - DKK
   - EUR
@@ -19,20 +24,26 @@ enum:
   - IDR
   - ILS
   - INR
+  - JOD
   - JPY
   - KRW
+  - MNT
+  - MUR
   - MXN
   - MYR
+  - NGN
   - NOK
   - NZD
   - PHP
   - PLN
   - RON
   - RUB
+  - SAR
   - SEK
   - SGD
   - THB
   - TRY
   - USD
+  - VND
   - ZAR
 default: USD

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1134,6 +1134,8 @@ paths:
     $ref: paths/api@accounts.yaml
   /api/accounts/available-roles:
     $ref: paths/api@accounts@available-roles.yaml
+  /api/accounts/{id}/available-roles:
+    $ref: paths/api@accounts@id@available-roles.yaml
   /api/accounts/{id}:
     $ref: paths/api@accounts@id.yaml
   /api/accounts/{accountId}/groups:

--- a/paths/api@accounts.yaml
+++ b/paths/api@accounts.yaml
@@ -87,7 +87,30 @@ post:
                   description: The subdomain. This will be part of the login URL and username for sub tenant users.
                   example: tt
                 currency:
-                  $ref: ../components/schemas/CurrencyCode.yaml
+                  type: string
+                  description: Currency ISO 4217 code for the tenant (e.g. USD, EUR, GBP). Must be a currency enabled on the target appliance; see the `currencies` option source (GET /api/options/currencies) for the live set. See CurrencyCode for the canonical ISO 4217 list.
+                  default: USD
+                  example: USD
+                active:
+                  type: boolean
+                  description: Whether the tenant is enabled. Disabled tenants cannot be logged into.
+                  default: true
+                  example: true
+                accountNumber:
+                  type:
+                    - string
+                    - 'null'
+                  description: An optional field that can be used for billing and accounting.
+                accountName:
+                  type:
+                    - string
+                    - 'null'
+                  description: An optional field that can be used for billing and accounting.
+                customerNumber:
+                  type:
+                    - string
+                    - 'null'
+                  description: An optional field that can be used for billing and accounting.
   responses:
     '200':
       description: Tenant Object

--- a/paths/api@accounts@id.yaml
+++ b/paths/api@accounts@id.yaml
@@ -64,7 +64,26 @@ put:
                     - 'null'
                   description: The subdomain. This will be part of the login URL and username for sub tenant users.
                 currency:
-                  $ref: ../components/schemas/CurrencyCode.yaml
+                  type: string
+                  description: Currency ISO 4217 code for the tenant (e.g. USD, EUR, GBP). Must be a currency enabled on the target appliance; see the `currencies` option source (GET /api/options/currencies) for the live set. See CurrencyCode for the canonical ISO 4217 list.
+                active:
+                  type: boolean
+                  description: Whether the tenant is enabled. Disabled tenants cannot be logged into.
+                accountNumber:
+                  type:
+                    - string
+                    - 'null'
+                  description: An optional field that can be used for billing and accounting.
+                accountName:
+                  type:
+                    - string
+                    - 'null'
+                  description: An optional field that can be used for billing and accounting.
+                customerNumber:
+                  type:
+                    - string
+                    - 'null'
+                  description: An optional field that can be used for billing and accounting.
   responses:
     '200':
       description: Tenant Object

--- a/paths/api@accounts@id@available-roles.yaml
+++ b/paths/api@accounts@id@available-roles.yaml
@@ -1,0 +1,27 @@
+get:
+  summary: List available base roles for a tenant
+  description: >-
+    Get the list of account roles that can be assigned as the base role for a
+    tenant, scoped to the tenant identified by the path id. This mirrors the
+    validation the tenant create endpoint performs against the parent tenant's
+    available roles.
+  operationId: listTenantAvailableRoles
+  tags:
+    - Tenants
+  parameters:
+    - $ref: ../components/parameters/id-path.yaml
+  responses:
+    '200':
+      description: Array of roles
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/tenantsAvailableRoles.yaml
+          examples:
+            Tenants Available Roles Response:
+              value:
+                $ref: ../components/examples/tenantsAvailableRoles.json
+    '4XX':
+      $ref: ../components/responses/4xx.yaml
+    '5XX':
+      $ref: ../components/responses/5xx.yaml


### PR DESCRIPTION
## Summary

Expands the tenant (account) API models and endpoints to match Morpheus appliance capabilities, in support of the Terraform provider's tenant resource (MORPH-16404).

## Changes

- **Create and update request payloads** (`/api/accounts` POST, `/api/accounts/{id}` PUT): add the writable `active`, `accountNumber`, `accountName`, and `customerNumber` fields to the tenant account schema. These are accepted by the appliance today but were undocumented.
- **New endpoint** `GET /api/accounts/{id}/available-roles` (`operationId: listTenantAvailableRoles`): lists the account roles assignable as the base role for a specific tenant. Mirrors the validation the tenant create endpoint performs against the parent tenant's available roles.
- **Currency**: widen the `CurrencyCode` enum from 34 to 45 seeded ISO 4217 codes (AED, ARS, AZN, BWP, COP, JOD, MNT, MUR, NGN, SAR, VND). The tenant request bodies now bind `currency` as a plain string documenting the dynamic per-appliance currency set, with `CurrencyCode` retained as the canonical reference list.

## Notes

- Targets `tf-dev`.
- No changes to response schemas; the read model already exposes these fields.
